### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/695/421166695.geojson
+++ b/data/421/166/695/421166695.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008699,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c08fa20a3115f24c78c6d801f8dbf81a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421166695,
-    "wof:lastmodified":1566646214,
+    "wof:lastmodified":1582393015,
     "wof:name":"Diaz",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/166/897/421166897.geojson
+++ b/data/421/166/897/421166897.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008706,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"917d03e469579e4099b8a6cf756f4b54",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421166897,
-    "wof:lastmodified":1566646215,
+    "wof:lastmodified":1582393015,
     "wof:name":"Acevedo",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/166/905/421166905.geojson
+++ b/data/421/166/905/421166905.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008706,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a399ac326b074dd0b9b2cd011fb91d16",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421166905,
-    "wof:lastmodified":1566646214,
+    "wof:lastmodified":1582393015,
     "wof:name":"Aragua",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/169/209/421169209.geojson
+++ b/data/421/169/209/421169209.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008799,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e170ef8ec1fbf3858fa9cdae4c3a5cc",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421169209,
-    "wof:lastmodified":1566646228,
+    "wof:lastmodified":1582393017,
     "wof:name":"Vargas",
     "wof:parent_id":85680533,
     "wof:placetype":"county",

--- a/data/421/169/421/421169421.geojson
+++ b/data/421/169/421/421169421.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008809,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a078c0ea2283565f410c3dcebdc592eb",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421169421,
-    "wof:lastmodified":1566646228,
+    "wof:lastmodified":1582393017,
     "wof:name":"Tovar",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/169/577/421169577.geojson
+++ b/data/421/169/577/421169577.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008816,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"897b0ca6482cf4e0bcaa060722601785",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421169577,
-    "wof:lastmodified":1566646228,
+    "wof:lastmodified":1582393017,
     "wof:name":"San Antonio de Los Altos",
     "wof:parent_id":421177411,
     "wof:placetype":"localadmin",

--- a/data/421/169/951/421169951.geojson
+++ b/data/421/169/951/421169951.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008830,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7910cd34d5d15eba2501fee83966c85b",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421169951,
-    "wof:lastmodified":1566646228,
+    "wof:lastmodified":1582393017,
     "wof:name":"Petit",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/170/033/421170033.geojson
+++ b/data/421/170/033/421170033.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7ebd7272b0408fca9007b40157ceb5f",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":421170033,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393025,
     "wof:name":"Mari\u00f1o",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/035/421170035.geojson
+++ b/data/421/170/035/421170035.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb87638dc3465ebda26c54496c06812d",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421170035,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393025,
     "wof:name":"Garcia",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/041/421170041.geojson
+++ b/data/421/170/041/421170041.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008834,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d25d8dc3ae72fda53c38f342e088148b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170041,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Catia la Mar",
     "wof:parent_id":421169209,
     "wof:placetype":"localadmin",

--- a/data/421/170/157/421170157.geojson
+++ b/data/421/170/157/421170157.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008840,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d5bae4a91ada6877ff1a2da671a9d5b",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421170157,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Arismendi",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/175/421170175.geojson
+++ b/data/421/170/175/421170175.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe2df3e30227c4d978df25e8c5e4914e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170175,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Urbana Fraternidad",
     "wof:parent_id":421198089,
     "wof:placetype":"localadmin",

--- a/data/421/170/177/421170177.geojson
+++ b/data/421/170/177/421170177.geojson
@@ -529,6 +529,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93e8f3486b72407a01dc3ea9e6951833",
     "wof:hierarchy":[
         {
@@ -540,7 +543,7 @@
         }
     ],
     "wof:id":421170177,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393025,
     "wof:name":"San Francisco",
     "wof:parent_id":1108694391,
     "wof:placetype":"localadmin",

--- a/data/421/170/179/421170179.geojson
+++ b/data/421/170/179/421170179.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd7aab168fe49a90b185c9235b850bb6",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170179,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393026,
     "wof:name":"Capital Gran Sabana",
     "wof:parent_id":421202369,
     "wof:placetype":"localadmin",

--- a/data/421/170/181/421170181.geojson
+++ b/data/421/170/181/421170181.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e3e037f14b338ad8cd16e0bc5f66fa64",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170181,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Capital Girardot",
     "wof:parent_id":421171995,
     "wof:placetype":"localadmin",

--- a/data/421/170/185/421170185.geojson
+++ b/data/421/170/185/421170185.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d17147bd769c68b770f913f69b4e326",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421170185,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393026,
     "wof:name":"Urbana Elorza",
     "wof:parent_id":421180899,
     "wof:placetype":"localadmin",

--- a/data/421/170/187/421170187.geojson
+++ b/data/421/170/187/421170187.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008841,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4664714b35aa1e78d834c94d5362bb75",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421170187,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Simon Rodriguez",
     "wof:parent_id":421189069,
     "wof:placetype":"localadmin",

--- a/data/421/170/247/421170247.geojson
+++ b/data/421/170/247/421170247.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008845,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5bf015e0c77c39db7fef97819285fd45",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421170247,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Urdaneta",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/375/421171375.geojson
+++ b/data/421/171/375/421171375.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89f2165d13c761d3c4b0cd4ba5f819e1",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171375,
-    "wof:lastmodified":1566646303,
+    "wof:lastmodified":1582393027,
     "wof:name":"San Cristobal",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/171/377/421171377.geojson
+++ b/data/421/171/377/421171377.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7087e6274b719f8f6c79ab3c8be4c81",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421171377,
-    "wof:lastmodified":1566646300,
+    "wof:lastmodified":1582393027,
     "wof:name":"Baruta",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/381/421171381.geojson
+++ b/data/421/171/381/421171381.geojson
@@ -429,6 +429,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f2191a7cbb82298919051539f7fe0e3",
     "wof:hierarchy":[
         {
@@ -439,7 +442,7 @@
         }
     ],
     "wof:id":421171381,
-    "wof:lastmodified":1566646303,
+    "wof:lastmodified":1582393027,
     "wof:name":"Sucre",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/639/421171639.geojson
+++ b/data/421/171/639/421171639.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"741b0b972f0bba1c75d6cdcaa7fa057d",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421171639,
-    "wof:lastmodified":1566646302,
+    "wof:lastmodified":1582393027,
     "wof:name":"Heres",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/171/643/421171643.geojson
+++ b/data/421/171/643/421171643.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e7c9472ae535164965bb74f782f17ae",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":421171643,
-    "wof:lastmodified":1566646298,
+    "wof:lastmodified":1582393026,
     "wof:name":"Brion",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/645/421171645.geojson
+++ b/data/421/171/645/421171645.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ca0f07a5ad8835263afeeac73bd1693",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421171645,
-    "wof:lastmodified":1566646298,
+    "wof:lastmodified":1582393026,
     "wof:name":"San Juan De Capistrano",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/171/647/421171647.geojson
+++ b/data/421/171/647/421171647.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"641b48f8722ffc490f4a995764d02480",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421171647,
-    "wof:lastmodified":1566646301,
+    "wof:lastmodified":1582393027,
     "wof:name":"Antonio Jose De Sucre",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/171/649/421171649.geojson
+++ b/data/421/171/649/421171649.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f67254b4047f5aaab56f81385579ce6",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421171649,
-    "wof:lastmodified":1566646301,
+    "wof:lastmodified":1582393027,
     "wof:name":"Pedro Camejo",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/171/651/421171651.geojson
+++ b/data/421/171/651/421171651.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c633d0e5b1b15531a7dcf17882ea4f1a",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421171651,
-    "wof:lastmodified":1566646299,
+    "wof:lastmodified":1582393027,
     "wof:name":"Achaguas",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/171/661/421171661.geojson
+++ b/data/421/171/661/421171661.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55f28c468978bdad301600170452eed7",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421171661,
-    "wof:lastmodified":1566646300,
+    "wof:lastmodified":1582393027,
     "wof:name":"Araure",
     "wof:parent_id":1108694093,
     "wof:placetype":"localadmin",

--- a/data/421/171/667/421171667.geojson
+++ b/data/421/171/667/421171667.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1a748d746fbaad75edc774486d25d3c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171667,
-    "wof:lastmodified":1566646300,
+    "wof:lastmodified":1582393027,
     "wof:name":"Leoncio Martinez",
     "wof:parent_id":421171381,
     "wof:placetype":"localadmin",

--- a/data/421/171/669/421171669.geojson
+++ b/data/421/171/669/421171669.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c592fc341c294f556fd17062ab78b9eb",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171669,
-    "wof:lastmodified":1566646299,
+    "wof:lastmodified":1582393027,
     "wof:name":"Capital Cardenal Quintero",
     "wof:parent_id":421194993,
     "wof:placetype":"localadmin",

--- a/data/421/171/671/421171671.geojson
+++ b/data/421/171/671/421171671.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6517330d61d6b8e444879f3eb0ba73f1",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171671,
-    "wof:lastmodified":1566646301,
+    "wof:lastmodified":1582393027,
     "wof:name":"Urbana San Jose",
     "wof:parent_id":421202373,
     "wof:placetype":"localadmin",

--- a/data/421/171/673/421171673.geojson
+++ b/data/421/171/673/421171673.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008902,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf554e3163befc4b5450d1f27a379f40",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421171673,
-    "wof:lastmodified":1566646299,
+    "wof:lastmodified":1582393027,
     "wof:name":"Urbana Juan Jose Flores",
     "wof:parent_id":421198089,
     "wof:placetype":"localadmin",

--- a/data/421/171/913/421171913.geojson
+++ b/data/421/171/913/421171913.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008911,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"222a57538253044257c7fb6501c875c2",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421171913,
-    "wof:lastmodified":1566646300,
+    "wof:lastmodified":1582393027,
     "wof:name":"Cristobal Rojas",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/995/421171995.geojson
+++ b/data/421/171/995/421171995.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa8276c1391152d81167b31b1947a7d0",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421171995,
-    "wof:lastmodified":1566646301,
+    "wof:lastmodified":1582393027,
     "wof:name":"Girardot",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/171/997/421171997.geojson
+++ b/data/421/171/997/421171997.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad701e6a92f59990ca10a2a1f50e6df2",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171997,
-    "wof:lastmodified":1566646297,
+    "wof:lastmodified":1582393026,
     "wof:name":"Antonio Pinto Salinas",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/171/999/421171999.geojson
+++ b/data/421/171/999/421171999.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008915,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d81f2fbb4f764642550b332bb51b557f",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421171999,
-    "wof:lastmodified":1566646298,
+    "wof:lastmodified":1582393026,
     "wof:name":"Campo Elias",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/172/277/421172277.geojson
+++ b/data/421/172/277/421172277.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008929,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a9249cd0fadd6e20d63fcbc2dea260b",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421172277,
-    "wof:lastmodified":1566646255,
+    "wof:lastmodified":1582393020,
     "wof:name":"Nirgua",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/172/279/421172279.geojson
+++ b/data/421/172/279/421172279.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008929,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1fbdf70f80af1c3f59556536b5b48529",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421172279,
-    "wof:lastmodified":1566646255,
+    "wof:lastmodified":1582393020,
     "wof:name":"Bejuma",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/172/511/421172511.geojson
+++ b/data/421/172/511/421172511.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008945,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eff9064f7a886ed20d14337f8ab6d215",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172511,
-    "wof:lastmodified":1566646254,
+    "wof:lastmodified":1582393020,
     "wof:name":"Jose Maria Vargas",
     "wof:parent_id":421202065,
     "wof:placetype":"localadmin",

--- a/data/421/172/589/421172589.geojson
+++ b/data/421/172/589/421172589.geojson
@@ -298,6 +298,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008947,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"378748586de803d40674476ed26b8a73",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         }
     ],
     "wof:id":421172589,
-    "wof:lastmodified":1566646254,
+    "wof:lastmodified":1582393020,
     "wof:name":"Maracaibo",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/172/597/421172597.geojson
+++ b/data/421/172/597/421172597.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c74f2cdecac063bfd5a4912d2fc517b",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421172597,
-    "wof:lastmodified":1566646255,
+    "wof:lastmodified":1582393020,
     "wof:name":"Pe\u00f1alver",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/172/599/421172599.geojson
+++ b/data/421/172/599/421172599.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c688edf7160c98f02cfca6f94a0be6d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421172599,
-    "wof:lastmodified":1566646255,
+    "wof:lastmodified":1582393020,
     "wof:name":"Maneiro",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/172/601/421172601.geojson
+++ b/data/421/172/601/421172601.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95f02c517ee91e0597b254fc76546862",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421172601,
-    "wof:lastmodified":1566646256,
+    "wof:lastmodified":1582393020,
     "wof:name":"Cruz Salmeron Acosta",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/172/603/421172603.geojson
+++ b/data/421/172/603/421172603.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f0d7414c6d28ad1c814943b74c0d225",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421172603,
-    "wof:lastmodified":1566646252,
+    "wof:lastmodified":1582393020,
     "wof:name":"Justo Brice\u00f1o",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/172/605/421172605.geojson
+++ b/data/421/172/605/421172605.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"361de17f74a3c40e6834bbc9c496218d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421172605,
-    "wof:lastmodified":1566646252,
+    "wof:lastmodified":1582393020,
     "wof:name":"Urdaneta",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/172/607/421172607.geojson
+++ b/data/421/172/607/421172607.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e7f4f0d4bfde9dbbc8f2da58f5b4fb0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172607,
-    "wof:lastmodified":1566646256,
+    "wof:lastmodified":1582393021,
     "wof:name":"Lasso de la Vega",
     "wof:parent_id":1108694253,
     "wof:placetype":"localadmin",

--- a/data/421/172/609/421172609.geojson
+++ b/data/421/172/609/421172609.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed912308f996a70c815a31af343c132a",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421172609,
-    "wof:lastmodified":1566646256,
+    "wof:lastmodified":1582393021,
     "wof:name":"Rafael Urdaneta",
     "wof:parent_id":421180477,
     "wof:placetype":"localadmin",

--- a/data/421/172/611/421172611.geojson
+++ b/data/421/172/611/421172611.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38b51e2426dcc325f2b33a443624db66",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172611,
-    "wof:lastmodified":1566646252,
+    "wof:lastmodified":1582393020,
     "wof:name":"Urbana Candelaria",
     "wof:parent_id":421202373,
     "wof:placetype":"localadmin",

--- a/data/421/172/615/421172615.geojson
+++ b/data/421/172/615/421172615.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008948,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"95b6ff1f7f1de7ee440aa90f0fe6524a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172615,
-    "wof:lastmodified":1566646255,
+    "wof:lastmodified":1582393020,
     "wof:name":"Capital Piar",
     "wof:parent_id":421197623,
     "wof:placetype":"localadmin",

--- a/data/421/172/921/421172921.geojson
+++ b/data/421/172/921/421172921.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008959,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ec6159eda9391c31836df558944e144",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172921,
-    "wof:lastmodified":1566646256,
+    "wof:lastmodified":1582393021,
     "wof:name":"Cua",
     "wof:parent_id":421170247,
     "wof:placetype":"localadmin",

--- a/data/421/172/923/421172923.geojson
+++ b/data/421/172/923/421172923.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008959,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc2eb734fd2b7d89301c670275df3998",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421172923,
-    "wof:lastmodified":1566646253,
+    "wof:lastmodified":1582393020,
     "wof:name":"Rio Chico",
     "wof:parent_id":421204299,
     "wof:placetype":"localadmin",

--- a/data/421/173/573/421173573.geojson
+++ b/data/421/173/573/421173573.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459008990,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0f3d23852c5f53e89221bf23a406c7f",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421173573,
-    "wof:lastmodified":1566646245,
+    "wof:lastmodified":1582393019,
     "wof:name":"Alberto Adriani",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/173/741/421173741.geojson
+++ b/data/421/173/741/421173741.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eae2e7da8f39781e1d385a51dfe53dce",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421173741,
-    "wof:lastmodified":1504913332,
+    "wof:lastmodified":1582393019,
     "wof:name":"Atures",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/421/173/879/421173879.geojson
+++ b/data/421/173/879/421173879.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009009,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02719968d10fd6ecb47c381c20133612",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421173879,
-    "wof:lastmodified":1566646245,
+    "wof:lastmodified":1582393019,
     "wof:name":"San Antonio del T\u00e1chira",
     "wof:parent_id":421185265,
     "wof:placetype":"locality",

--- a/data/421/175/071/421175071.geojson
+++ b/data/421/175/071/421175071.geojson
@@ -255,6 +255,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009054,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"000fb995962dc37f5349a15d961c0617",
     "wof:hierarchy":[
         {
@@ -265,7 +268,7 @@
         }
     ],
     "wof:id":421175071,
-    "wof:lastmodified":1566646266,
+    "wof:lastmodified":1582393021,
     "wof:name":"Anaco",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/175/381/421175381.geojson
+++ b/data/421/175/381/421175381.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec17d6e251249f5faaeb686f3341955b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421175381,
-    "wof:lastmodified":1566646267,
+    "wof:lastmodified":1582393022,
     "wof:name":"Arzobispo Chacon",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/175/383/421175383.geojson
+++ b/data/421/175/383/421175383.geojson
@@ -429,6 +429,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009065,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba80442efe132e257643fee0bafcddfb",
     "wof:hierarchy":[
         {
@@ -439,7 +442,7 @@
         }
     ],
     "wof:id":421175383,
-    "wof:lastmodified":1566646266,
+    "wof:lastmodified":1582393021,
     "wof:name":"Sucre",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/175/845/421175845.geojson
+++ b/data/421/175/845/421175845.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009081,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"516ec8f7821fa00abfe0bb516d70de58",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421175845,
-    "wof:lastmodified":1566646266,
+    "wof:lastmodified":1582393021,
     "wof:name":"El Lim\u00f3n",
     "wof:parent_id":421169209,
     "wof:placetype":"locality",

--- a/data/421/176/711/421176711.geojson
+++ b/data/421/176/711/421176711.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a19674595837cf89bb5189fc8498d0ca",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421176711,
-    "wof:lastmodified":1566646297,
+    "wof:lastmodified":1582393026,
     "wof:name":"Peninsula de Macanao",
     "wof:parent_id":890440759,
     "wof:placetype":"localadmin",

--- a/data/421/177/379/421177379.geojson
+++ b/data/421/177/379/421177379.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009142,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ae06ba3710ccbece393d390843fd0bb",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421177379,
-    "wof:lastmodified":1566646290,
+    "wof:lastmodified":1582393026,
     "wof:name":"San Jose de Guanipa",
     "wof:parent_id":421182997,
     "wof:placetype":"localadmin",

--- a/data/421/177/403/421177403.geojson
+++ b/data/421/177/403/421177403.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009143,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"66f2a79168253b2943c681a0f0894314",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421177403,
-    "wof:lastmodified":1566646290,
+    "wof:lastmodified":1582393026,
     "wof:name":"El Cafetal",
     "wof:parent_id":421171377,
     "wof:placetype":"localadmin",

--- a/data/421/177/411/421177411.geojson
+++ b/data/421/177/411/421177411.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009143,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c037cb6487a785a11af8ccf4805aae1",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421177411,
-    "wof:lastmodified":1566646290,
+    "wof:lastmodified":1582393026,
     "wof:name":"Los Salias",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/177/413/421177413.geojson
+++ b/data/421/177/413/421177413.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009143,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97f40bb1ba96a8620cf2b5824e689c40",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421177413,
-    "wof:lastmodified":1566646289,
+    "wof:lastmodified":1582393026,
     "wof:name":"Villalba",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/177/421/421177421.geojson
+++ b/data/421/177/421/421177421.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009144,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e05be35b85fa42944530634e7c60de3f",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421177421,
-    "wof:lastmodified":1566646290,
+    "wof:lastmodified":1582393026,
     "wof:name":"Aguasay",
     "wof:parent_id":1108694065,
     "wof:placetype":"localadmin",

--- a/data/421/178/891/421178891.geojson
+++ b/data/421/178/891/421178891.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009197,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"716bb0835b7dfc54edfe646753c1adcb",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421178891,
-    "wof:lastmodified":1566646295,
+    "wof:lastmodified":1582393026,
     "wof:name":"Baraived",
     "wof:parent_id":421180891,
     "wof:placetype":"localadmin",

--- a/data/421/180/477/421180477.geojson
+++ b/data/421/180/477/421180477.geojson
@@ -479,6 +479,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009260,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4779f1e14baee071eaf2a2329b8a313",
     "wof:hierarchy":[
         {
@@ -489,7 +492,7 @@
         }
     ],
     "wof:id":421180477,
-    "wof:lastmodified":1566646239,
+    "wof:lastmodified":1582393018,
     "wof:name":"San Diego",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/180/891/421180891.geojson
+++ b/data/421/180/891/421180891.geojson
@@ -350,6 +350,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009274,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8dc9ce3f0ace2ad3bf1ad82d25ec28c",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         }
     ],
     "wof:id":421180891,
-    "wof:lastmodified":1566646240,
+    "wof:lastmodified":1582393018,
     "wof:name":"Falcon",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/180/895/421180895.geojson
+++ b/data/421/180/895/421180895.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009274,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f867bd349bd811e6f3ced06fa152652e",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421180895,
-    "wof:lastmodified":1566646240,
+    "wof:lastmodified":1582393018,
     "wof:name":"Iribarren",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/180/897/421180897.geojson
+++ b/data/421/180/897/421180897.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd166657475b19e5b0400ee7641384a4",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421180897,
-    "wof:lastmodified":1566646241,
+    "wof:lastmodified":1582393019,
     "wof:name":"Colina",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/180/899/421180899.geojson
+++ b/data/421/180/899/421180899.geojson
@@ -210,6 +210,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"438a12238408ebaeee5b15808e551654",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":421180899,
-    "wof:lastmodified":1566646241,
+    "wof:lastmodified":1582393019,
     "wof:name":"Romulo Gallegos",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/180/901/421180901.geojson
+++ b/data/421/180/901/421180901.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0b4186e815c287e2ac6c8424ca70e0b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421180901,
-    "wof:lastmodified":1566646239,
+    "wof:lastmodified":1582393018,
     "wof:name":"Antolin del Campo",
     "wof:parent_id":1108694081,
     "wof:placetype":"localadmin",

--- a/data/421/180/903/421180903.geojson
+++ b/data/421/180/903/421180903.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009275,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a15029ff46d279c061ae308dde89494e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421180903,
-    "wof:lastmodified":1566646240,
+    "wof:lastmodified":1582393018,
     "wof:name":"Concepcion",
     "wof:parent_id":421180895,
     "wof:placetype":"localadmin",

--- a/data/421/180/987/421180987.geojson
+++ b/data/421/180/987/421180987.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009278,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e61ca4b012ab87e4e5bb1b8517a0fd4",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421180987,
-    "wof:lastmodified":1566646241,
+    "wof:lastmodified":1582393019,
     "wof:name":"Capital Libertador",
     "wof:parent_id":421171995,
     "wof:placetype":"localadmin",

--- a/data/421/181/777/421181777.geojson
+++ b/data/421/181/777/421181777.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009306,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5da413783a590ceb1566902f5d4374dc",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421181777,
-    "wof:lastmodified":1566646263,
+    "wof:lastmodified":1582393021,
     "wof:name":"Jose Rafael Revenga",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/181/779/421181779.geojson
+++ b/data/421/181/779/421181779.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009306,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e918c50a96d900a159dfaa2d6084e393",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421181779,
-    "wof:lastmodified":1566646263,
+    "wof:lastmodified":1582393021,
     "wof:name":"Piritu",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/181/907/421181907.geojson
+++ b/data/421/181/907/421181907.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae6c3d84dbbe33bf774c3ead9ef2847b",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421181907,
-    "wof:lastmodified":1566646262,
+    "wof:lastmodified":1582393021,
     "wof:name":"Cruz Paredes",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/182/049/421182049.geojson
+++ b/data/421/182/049/421182049.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009317,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3122cca4955f62449f0e3558630d73c",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182049,
-    "wof:lastmodified":1566646295,
+    "wof:lastmodified":1582393026,
     "wof:name":"Escuque",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/182/143/421182143.geojson
+++ b/data/421/182/143/421182143.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009320,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a89654fcdd9b22c4dbd7e203e28b3387",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421182143,
-    "wof:lastmodified":1566646296,
+    "wof:lastmodified":1582393026,
     "wof:name":"Naguanagua",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/182/997/421182997.geojson
+++ b/data/421/182/997/421182997.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b12750ed2d8d9913bea809d04dba699",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182997,
-    "wof:lastmodified":1566646295,
+    "wof:lastmodified":1582393026,
     "wof:name":"Guanipa",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/183/021/421183021.geojson
+++ b/data/421/183/021/421183021.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009355,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3944577740bf3044bf1f7bc279f4f136",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183021,
-    "wof:lastmodified":1566646293,
+    "wof:lastmodified":1582393026,
     "wof:name":"Mamo",
     "wof:parent_id":421190237,
     "wof:placetype":"localadmin",

--- a/data/421/183/169/421183169.geojson
+++ b/data/421/183/169/421183169.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009360,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4eb28c27f0c42366e4f415bf832656f",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421183169,
-    "wof:lastmodified":1566646291,
+    "wof:lastmodified":1582393026,
     "wof:name":"Andres Eloy Blanco",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/183/171/421183171.geojson
+++ b/data/421/183/171/421183171.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009360,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"171fb5176a1c7e8f960d4e878b2a83d0",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421183171,
-    "wof:lastmodified":1566646294,
+    "wof:lastmodified":1582393026,
     "wof:name":"Uribante",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/183/211/421183211.geojson
+++ b/data/421/183/211/421183211.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009362,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e4ccfa0ca948c51ff49a0c47720b28d",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183211,
-    "wof:lastmodified":1566646291,
+    "wof:lastmodified":1582393026,
     "wof:name":"Samuel Dario Maldonado",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/183/227/421183227.geojson
+++ b/data/421/183/227/421183227.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009362,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"125646d4d0318e73220559298c2ea50d",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421183227,
-    "wof:lastmodified":1566646291,
+    "wof:lastmodified":1582393026,
     "wof:name":"Freites",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/183/445/421183445.geojson
+++ b/data/421/183/445/421183445.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009369,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e349150e5d268439aad65003c463cf7c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421183445,
-    "wof:lastmodified":1566646293,
+    "wof:lastmodified":1582393026,
     "wof:name":"Casacoima",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/421/183/447/421183447.geojson
+++ b/data/421/183/447/421183447.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009369,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0b9bb4a8d47b5cdab8abde7832f45e2",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183447,
-    "wof:lastmodified":1566646291,
+    "wof:lastmodified":1582393026,
     "wof:name":"Urbana San Blas",
     "wof:parent_id":421202373,
     "wof:placetype":"localadmin",

--- a/data/421/183/451/421183451.geojson
+++ b/data/421/183/451/421183451.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009369,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"36a4242035c5fd972d48323ccc22ba71",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421183451,
-    "wof:lastmodified":1566646293,
+    "wof:lastmodified":1582393026,
     "wof:name":"Capital Camatagua",
     "wof:parent_id":421193519,
     "wof:placetype":"localadmin",

--- a/data/421/183/685/421183685.geojson
+++ b/data/421/183/685/421183685.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009378,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f403bdace1289c093e900f78ab80f9c1",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421183685,
-    "wof:lastmodified":1566646292,
+    "wof:lastmodified":1582393026,
     "wof:name":"Las Tejer\u00edas",
     "wof:parent_id":421202375,
     "wof:placetype":"locality",

--- a/data/421/184/145/421184145.geojson
+++ b/data/421/184/145/421184145.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0804c5ff173cb223316dc9895415a7a5",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":421184145,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"Altagracia",
     "wof:parent_id":1108694139,
     "wof:placetype":"localadmin",

--- a/data/421/184/195/421184195.geojson
+++ b/data/421/184/195/421184195.geojson
@@ -240,6 +240,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009403,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"480a03f9bb27bc0aacb581dd5ca6d427",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
         }
     ],
     "wof:id":421184195,
-    "wof:lastmodified":1566646284,
+    "wof:lastmodified":1582393025,
     "wof:name":"Miranda",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/184/197/421184197.geojson
+++ b/data/421/184/197/421184197.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009403,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba5b51d20254612acce600943ff19e98",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":421184197,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"Ricaurte",
     "wof:parent_id":421196977,
     "wof:placetype":"localadmin",

--- a/data/421/184/199/421184199.geojson
+++ b/data/421/184/199/421184199.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009403,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"500a5d97c89f370fe0c466b0ec3aed52",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421184199,
-    "wof:lastmodified":1566646287,
+    "wof:lastmodified":1582393025,
     "wof:name":"San Rafael",
     "wof:parent_id":421196977,
     "wof:placetype":"localadmin",

--- a/data/421/184/293/421184293.geojson
+++ b/data/421/184/293/421184293.geojson
@@ -184,6 +184,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009406,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b61cbca41ff56407efbaea20d6de5b4",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421184293,
-    "wof:lastmodified":1566646285,
+    "wof:lastmodified":1582393025,
     "wof:name":"Zamora",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/184/299/421184299.geojson
+++ b/data/421/184/299/421184299.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009406,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d79ece57ae8284f5ce215552206b809",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421184299,
-    "wof:lastmodified":1566646287,
+    "wof:lastmodified":1582393025,
     "wof:name":"Calabozo",
     "wof:parent_id":1108694293,
     "wof:placetype":"localadmin",

--- a/data/421/184/341/421184341.geojson
+++ b/data/421/184/341/421184341.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009408,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d6b871dd3f041d5f3ebff63c43e683f",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421184341,
-    "wof:lastmodified":1566646285,
+    "wof:lastmodified":1582393025,
     "wof:name":"San Silvestre",
     "wof:parent_id":890429493,
     "wof:placetype":"localadmin",

--- a/data/421/184/351/421184351.geojson
+++ b/data/421/184/351/421184351.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009408,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e67e87813a7108c3ac9060545c706ce",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421184351,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"Santos Marquina",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/184/387/421184387.geojson
+++ b/data/421/184/387/421184387.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009409,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f6633c3b8e627f138d6d3f408049c241",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421184387,
-    "wof:lastmodified":1566646287,
+    "wof:lastmodified":1582393025,
     "wof:name":"Pedro Gual",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/184/557/421184557.geojson
+++ b/data/421/184/557/421184557.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009414,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2272b6929f73287718c2cddc8026cd81",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421184557,
-    "wof:lastmodified":1566646285,
+    "wof:lastmodified":1582393025,
     "wof:name":"Jose Felix Ribas",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/184/701/421184701.geojson
+++ b/data/421/184/701/421184701.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39f4753fdaf078e6d18fb220c2ae43e7",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184701,
-    "wof:lastmodified":1566646284,
+    "wof:lastmodified":1582393025,
     "wof:name":"Capital Ayacucho",
     "wof:parent_id":421189269,
     "wof:placetype":"localadmin",

--- a/data/421/184/703/421184703.geojson
+++ b/data/421/184/703/421184703.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52b164cf5dd2e5ab0e6047f941af1699",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184703,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"Gonzalo Picon Febres",
     "wof:parent_id":421190239,
     "wof:placetype":"localadmin",

--- a/data/421/184/705/421184705.geojson
+++ b/data/421/184/705/421184705.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1df958cfc8eed95e5775b3c5a8a8b0ac",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184705,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"Pi\u00f1ango",
     "wof:parent_id":1108694297,
     "wof:placetype":"localadmin",

--- a/data/421/184/711/421184711.geojson
+++ b/data/421/184/711/421184711.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec9ae5ee8226f333b4a4bf6557066d78",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184711,
-    "wof:lastmodified":1566646288,
+    "wof:lastmodified":1582393025,
     "wof:name":"Santos Marquina",
     "wof:parent_id":421184351,
     "wof:placetype":"localadmin",

--- a/data/421/184/923/421184923.geojson
+++ b/data/421/184/923/421184923.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009426,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67e58c1cf876cd7ac3151879434fe51e",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421184923,
-    "wof:lastmodified":1566646286,
+    "wof:lastmodified":1582393025,
     "wof:name":"El Morro",
     "wof:parent_id":1108694253,
     "wof:placetype":"localadmin",

--- a/data/421/184/933/421184933.geojson
+++ b/data/421/184/933/421184933.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009427,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a801272601709771daa44e2076ad215",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":421184933,
-    "wof:lastmodified":1566646287,
+    "wof:lastmodified":1582393025,
     "wof:name":"Macarao",
     "wof:parent_id":1108694091,
     "wof:placetype":"localadmin",

--- a/data/421/184/963/421184963.geojson
+++ b/data/421/184/963/421184963.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009428,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d256e19eab5bad8fce20123e65aa13da",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421184963,
-    "wof:lastmodified":1566646285,
+    "wof:lastmodified":1582393025,
     "wof:name":"Ortiz",
     "wof:parent_id":1108694319,
     "wof:placetype":"localadmin",

--- a/data/421/184/969/421184969.geojson
+++ b/data/421/184/969/421184969.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009428,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ba8a00a72b22e2748121ae3bfa49963",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421184969,
-    "wof:lastmodified":1566646287,
+    "wof:lastmodified":1582393025,
     "wof:name":"Boca de Uchire",
     "wof:parent_id":421171645,
     "wof:placetype":"localadmin",

--- a/data/421/185/095/421185095.geojson
+++ b/data/421/185/095/421185095.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009432,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d85558a0d8cb5a05c0d7ad4fbf20906",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421185095,
-    "wof:lastmodified":1566646305,
+    "wof:lastmodified":1582393027,
     "wof:name":"Bolivar",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/185/127/421185127.geojson
+++ b/data/421/185/127/421185127.geojson
@@ -141,6 +141,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009433,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae44b8af73db6809ea1dbbbc3106149c",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":421185127,
-    "wof:lastmodified":1566646304,
+    "wof:lastmodified":1582393027,
     "wof:name":"Acosta",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/185/263/421185263.geojson
+++ b/data/421/185/263/421185263.geojson
@@ -315,6 +315,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009437,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d7eb472fe6b27a20a346eb602a7c838",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         }
     ],
     "wof:id":421185263,
-    "wof:lastmodified":1566646306,
+    "wof:lastmodified":1582393027,
     "wof:name":"Pe\u00f1a",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/185/265/421185265.geojson
+++ b/data/421/185/265/421185265.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009437,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9777febef75e263d2d24e9b69a790be2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421185265,
-    "wof:lastmodified":1566646306,
+    "wof:lastmodified":1582393027,
     "wof:name":"Cordova",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/185/893/421185893.geojson
+++ b/data/421/185/893/421185893.geojson
@@ -258,6 +258,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009457,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8c75355201c43448d8e92c87822a6d6",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         }
     ],
     "wof:id":421185893,
-    "wof:lastmodified":1566646304,
+    "wof:lastmodified":1582393027,
     "wof:name":"San Fernando de Apure",
     "wof:parent_id":1108694389,
     "wof:placetype":"locality",

--- a/data/421/185/957/421185957.geojson
+++ b/data/421/185/957/421185957.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009460,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f17cf283deb18bf1bff92ceab6ccd9d7",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":421185957,
-    "wof:lastmodified":1566646305,
+    "wof:lastmodified":1582393027,
     "wof:name":"Ejido",
     "wof:parent_id":1108694253,
     "wof:placetype":"locality",

--- a/data/421/186/159/421186159.geojson
+++ b/data/421/186/159/421186159.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009472,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4dc40db1f705adb09917b3240582081b",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421186159,
-    "wof:lastmodified":1566646257,
+    "wof:lastmodified":1582393021,
     "wof:name":"Andres Bello",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/186/263/421186263.geojson
+++ b/data/421/186/263/421186263.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009475,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1113c5718f13cd97d8cff0dfa615557",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421186263,
-    "wof:lastmodified":1566646260,
+    "wof:lastmodified":1582393021,
     "wof:name":"Santiago Mari\u00f1o",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/186/265/421186265.geojson
+++ b/data/421/186/265/421186265.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009475,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20befeb2aa2c8c5f138dd995d0fc5109",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421186265,
-    "wof:lastmodified":1566646260,
+    "wof:lastmodified":1582393021,
     "wof:name":"Caripe",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/421/186/375/421186375.geojson
+++ b/data/421/186/375/421186375.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009479,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67e0daa8cb5f5b2991a55a5e822bcb78",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421186375,
-    "wof:lastmodified":1566646261,
+    "wof:lastmodified":1582393021,
     "wof:name":"Maturin",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/421/186/435/421186435.geojson
+++ b/data/421/186/435/421186435.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009481,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2af79cc15efe34b2f38cbd4384cb9b05",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421186435,
-    "wof:lastmodified":1566646260,
+    "wof:lastmodified":1582393021,
     "wof:name":"Colon",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/186/937/421186937.geojson
+++ b/data/421/186/937/421186937.geojson
@@ -515,6 +515,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009496,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"402dfb20e7d6b69149af9a2f659563d0",
     "wof:hierarchy":[
         {
@@ -526,7 +529,7 @@
         }
     ],
     "wof:id":421186937,
-    "wof:lastmodified":1566646258,
+    "wof:lastmodified":1582393021,
     "wof:name":"M\u00e9rida",
     "wof:parent_id":1108694253,
     "wof:placetype":"locality",

--- a/data/421/186/957/421186957.geojson
+++ b/data/421/186/957/421186957.geojson
@@ -272,6 +272,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009497,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c965988f532ca1860052deb92dd39a25",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":421186957,
-    "wof:lastmodified":1566646259,
+    "wof:lastmodified":1582393021,
     "wof:name":"Punto Fijo",
     "wof:parent_id":890451975,
     "wof:placetype":"locality",

--- a/data/421/187/905/421187905.geojson
+++ b/data/421/187/905/421187905.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4df12f9957a5694074ada567404fc820",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421187905,
-    "wof:lastmodified":1566646242,
+    "wof:lastmodified":1582393019,
     "wof:name":"San Gabriel",
     "wof:parent_id":1108694291,
     "wof:placetype":"localadmin",

--- a/data/421/188/083/421188083.geojson
+++ b/data/421/188/083/421188083.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76125e7e198634b16823146bde0a3759",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421188083,
-    "wof:lastmodified":1566646251,
+    "wof:lastmodified":1582393020,
     "wof:name":"Bocono",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/188/591/421188591.geojson
+++ b/data/421/188/591/421188591.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009570,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4305d26e72b49f2769a966198ee7dcab",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421188591,
-    "wof:lastmodified":1566646252,
+    "wof:lastmodified":1582393020,
     "wof:name":"Buroz",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/188/709/421188709.geojson
+++ b/data/421/188/709/421188709.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009575,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b7c848a3e6a47f9e03e62b8a383e159",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421188709,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Monte Carmelo",
     "wof:parent_id":1108694309,
     "wof:placetype":"localadmin",

--- a/data/421/188/829/421188829.geojson
+++ b/data/421/188/829/421188829.geojson
@@ -345,6 +345,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009581,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8039c21e91b1081b2b4d4d394c9c109",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         }
     ],
     "wof:id":421188829,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Trujillo",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/188/833/421188833.geojson
+++ b/data/421/188/833/421188833.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009581,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddb79ee97fa4dd9fe664da478ef81f9d",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421188833,
-    "wof:lastmodified":1566646251,
+    "wof:lastmodified":1582393020,
     "wof:name":"San Joaquin",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/188/835/421188835.geojson
+++ b/data/421/188/835/421188835.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009581,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9209e8a8688ae8a59537193b60c694c5",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421188835,
-    "wof:lastmodified":1566646251,
+    "wof:lastmodified":1582393020,
     "wof:name":"Mario Brice\u00f1o Iragorri",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/188/845/421188845.geojson
+++ b/data/421/188/845/421188845.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009582,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68df9ccb5821595228a6bfecfe843fb6",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421188845,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Urbana Santa Rosa",
     "wof:parent_id":421202373,
     "wof:placetype":"localadmin",

--- a/data/421/189/069/421189069.geojson
+++ b/data/421/189/069/421189069.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e063ff76e60186fcc57cd4b06a6eea3b",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421189069,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Simon Rodriguez",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/189/073/421189073.geojson
+++ b/data/421/189/073/421189073.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009603,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0666bc5ae35b82e1424ccc885a0803a5",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421189073,
-    "wof:lastmodified":1566646249,
+    "wof:lastmodified":1582393019,
     "wof:name":"Jimenez",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/189/075/421189075.geojson
+++ b/data/421/189/075/421189075.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05f54de5e8564105ae1526ef23cd53ec",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421189075,
-    "wof:lastmodified":1566646249,
+    "wof:lastmodified":1582393020,
     "wof:name":"Carlos Arvelo",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/189/079/421189079.geojson
+++ b/data/421/189/079/421189079.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14e09892948d7679b8e1ef05069d35ae",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":421189079,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"Mellado",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/421/189/081/421189081.geojson
+++ b/data/421/189/081/421189081.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e17279f781cb25ebe036a9add8e24d9",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":421189081,
-    "wof:lastmodified":1566646249,
+    "wof:lastmodified":1582393019,
     "wof:name":"Plaza",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/189/087/421189087.geojson
+++ b/data/421/189/087/421189087.geojson
@@ -179,6 +179,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5c263860d81798199a63051eeae7201",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":421189087,
-    "wof:lastmodified":1566646249,
+    "wof:lastmodified":1582393019,
     "wof:name":"Guanare",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/421/189/091/421189091.geojson
+++ b/data/421/189/091/421189091.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"887ff35ca77d68bac2f02f6cc2c0a218",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421189091,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"Carmen Herrera",
     "wof:parent_id":421202059,
     "wof:placetype":"localadmin",

--- a/data/421/189/093/421189093.geojson
+++ b/data/421/189/093/421189093.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1353ddbec617bd69ebea5c0d80ab785c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189093,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"El Recreo",
     "wof:parent_id":1108694107,
     "wof:placetype":"localadmin",

--- a/data/421/189/097/421189097.geojson
+++ b/data/421/189/097/421189097.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"57a32a5652681a0364de9e2edb6f5f81",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189097,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"El Paraiso",
     "wof:parent_id":1108694091,
     "wof:placetype":"localadmin",

--- a/data/421/189/099/421189099.geojson
+++ b/data/421/189/099/421189099.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba51f93749138c108b7af59b72434f6e",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421189099,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"Delicias",
     "wof:parent_id":421185265,
     "wof:placetype":"localadmin",

--- a/data/421/189/103/421189103.geojson
+++ b/data/421/189/103/421189103.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb2f401dde1112679108e2cd0d67dc8a",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421189103,
-    "wof:lastmodified":1566646246,
+    "wof:lastmodified":1582393019,
     "wof:name":"Petare",
     "wof:parent_id":421171381,
     "wof:placetype":"localadmin",

--- a/data/421/189/105/421189105.geojson
+++ b/data/421/189/105/421189105.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fdedf05364195beef49913ec75ee60a8",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189105,
-    "wof:lastmodified":1566646246,
+    "wof:lastmodified":1582393019,
     "wof:name":"La Dolorita",
     "wof:parent_id":421171381,
     "wof:placetype":"localadmin",

--- a/data/421/189/107/421189107.geojson
+++ b/data/421/189/107/421189107.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af329f7f35455d404c03ee97d69e4ea4",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421189107,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"Guarenas",
     "wof:parent_id":421189081,
     "wof:placetype":"localadmin",

--- a/data/421/189/109/421189109.geojson
+++ b/data/421/189/109/421189109.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fe35ed7267992aa0e535ded33f8e13c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189109,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"El Hatillo",
     "wof:parent_id":421194073,
     "wof:placetype":"localadmin",

--- a/data/421/189/111/421189111.geojson
+++ b/data/421/189/111/421189111.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cdeeed44744b6fd0a1ab8a4c0b5ebb14",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421189111,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"Chacao",
     "wof:parent_id":1108694157,
     "wof:placetype":"localadmin",

--- a/data/421/189/113/421189113.geojson
+++ b/data/421/189/113/421189113.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a8b21cbacffd976c23bd8fd45000fcf",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189113,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Capital Santos Michelena",
     "wof:parent_id":1108694419,
     "wof:placetype":"localadmin",

--- a/data/421/189/115/421189115.geojson
+++ b/data/421/189/115/421189115.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b62c42a6a2085328e48eeaa2b26a06e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189115,
-    "wof:lastmodified":1566646250,
+    "wof:lastmodified":1582393020,
     "wof:name":"Puerto Piritu",
     "wof:parent_id":421181779,
     "wof:placetype":"localadmin",

--- a/data/421/189/117/421189117.geojson
+++ b/data/421/189/117/421189117.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009605,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf2f403bd28c158ab6e8812668348766",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189117,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"Urbana Naguanagua",
     "wof:parent_id":421182143,
     "wof:placetype":"localadmin",

--- a/data/421/189/269/421189269.geojson
+++ b/data/421/189/269/421189269.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23dc5880cf8d9b3732d0fef2a65e720f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421189269,
-    "wof:lastmodified":1566646248,
+    "wof:lastmodified":1582393019,
     "wof:name":"Ayacucho",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/189/477/421189477.geojson
+++ b/data/421/189/477/421189477.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f83b94d9828e43aad7c4b3644bb35442",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421189477,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"Mucutuy",
     "wof:parent_id":421175381,
     "wof:placetype":"localadmin",

--- a/data/421/189/483/421189483.geojson
+++ b/data/421/189/483/421189483.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f0ace5af82421460a01b736e2aa4187",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421189483,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"San Francisco de Yare",
     "wof:parent_id":1108694425,
     "wof:placetype":"localadmin",

--- a/data/421/189/485/421189485.geojson
+++ b/data/421/189/485/421189485.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f94be62a5de8e1bfad2d39652d075ced",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421189485,
-    "wof:lastmodified":1566646247,
+    "wof:lastmodified":1582393019,
     "wof:name":"Ocumare del Tuy",
     "wof:parent_id":1108694243,
     "wof:placetype":"localadmin",

--- a/data/421/190/213/421190213.geojson
+++ b/data/421/190/213/421190213.geojson
@@ -552,6 +552,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009650,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51eb8888ebbbec014dab16c4a44a28db",
     "wof:hierarchy":[
         {
@@ -562,7 +565,7 @@
         }
     ],
     "wof:id":421190213,
-    "wof:lastmodified":1566646278,
+    "wof:lastmodified":1582393024,
     "wof:name":"San Francisco",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/190/215/421190215.geojson
+++ b/data/421/190/215/421190215.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009650,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2777374956ae139a737a4ff42f35935",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421190215,
-    "wof:lastmodified":1566646278,
+    "wof:lastmodified":1582393024,
     "wof:name":"Libertad",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/190/237/421190237.geojson
+++ b/data/421/190/237/421190237.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009651,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"991b2f2dbbb37b313c7e64c18690f681",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421190237,
-    "wof:lastmodified":1566646279,
+    "wof:lastmodified":1582393024,
     "wof:name":"Caroni",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/190/239/421190239.geojson
+++ b/data/421/190/239/421190239.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009651,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5b381b9218cbc9baebcf6c8ffa08403",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421190239,
-    "wof:lastmodified":1566646279,
+    "wof:lastmodified":1582393024,
     "wof:name":"Rangel",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/190/785/421190785.geojson
+++ b/data/421/190/785/421190785.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009669,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65f86b896405c0a6c5833ab165b08d7d",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421190785,
-    "wof:lastmodified":1566646277,
+    "wof:lastmodified":1582393024,
     "wof:name":"Paez",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/191/427/421191427.geojson
+++ b/data/421/191/427/421191427.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86194e2148661adc4741e686300558c0",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421191427,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"San Juan Bautista",
     "wof:parent_id":421171375,
     "wof:placetype":"localadmin",

--- a/data/421/191/429/421191429.geojson
+++ b/data/421/191/429/421191429.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f159c304e3729bec6470e99e9b4365d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191429,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"Constitucion",
     "wof:parent_id":421195115,
     "wof:placetype":"localadmin",

--- a/data/421/191/431/421191431.geojson
+++ b/data/421/191/431/421191431.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"edf4ebb54ec644698f4332e101ac78a5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191431,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"Maneiro",
     "wof:parent_id":421172599,
     "wof:placetype":"localadmin",

--- a/data/421/191/433/421191433.geojson
+++ b/data/421/191/433/421191433.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da6a5d0dd2181ab332b0e421d06bb334",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421191433,
-    "wof:lastmodified":1566646276,
+    "wof:lastmodified":1582393023,
     "wof:name":"Villalba",
     "wof:parent_id":421177413,
     "wof:placetype":"localadmin",

--- a/data/421/191/435/421191435.geojson
+++ b/data/421/191/435/421191435.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85e0d46ff0962858591a859839571440",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191435,
-    "wof:lastmodified":1566646276,
+    "wof:lastmodified":1582393024,
     "wof:name":"Matasiete",
     "wof:parent_id":421202069,
     "wof:placetype":"localadmin",

--- a/data/421/191/439/421191439.geojson
+++ b/data/421/191/439/421191439.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3740bf9dbb47bd89279cecbdcf3d1037",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191439,
-    "wof:lastmodified":1566646274,
+    "wof:lastmodified":1582393023,
     "wof:name":"Alto de Los Godos",
     "wof:parent_id":421186375,
     "wof:placetype":"localadmin",

--- a/data/421/191/443/421191443.geojson
+++ b/data/421/191/443/421191443.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"841b9de837f42eca37e658fc096f7b4e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191443,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"Fernandez Pe\u00f1a",
     "wof:parent_id":1108694253,
     "wof:placetype":"localadmin",

--- a/data/421/191/445/421191445.geojson
+++ b/data/421/191/445/421191445.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06a8829137c5749ffdc507593bc01582",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421191445,
-    "wof:lastmodified":1566646276,
+    "wof:lastmodified":1582393023,
     "wof:name":"Norte",
     "wof:parent_id":890451975,
     "wof:placetype":"localadmin",

--- a/data/421/191/447/421191447.geojson
+++ b/data/421/191/447/421191447.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7ab0fae410f70487b9ca521ff56b864",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191447,
-    "wof:lastmodified":1566646274,
+    "wof:lastmodified":1582393023,
     "wof:name":"Arevalo Aponte",
     "wof:parent_id":421171995,
     "wof:placetype":"localadmin",

--- a/data/421/191/449/421191449.geojson
+++ b/data/421/191/449/421191449.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e76a4e66b9c6e1c3ad31605e7e9771f5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191449,
-    "wof:lastmodified":1566646274,
+    "wof:lastmodified":1582393023,
     "wof:name":"Urbana San Diego",
     "wof:parent_id":421180477,
     "wof:placetype":"localadmin",

--- a/data/421/191/451/421191451.geojson
+++ b/data/421/191/451/421191451.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82cafd43bf75ac3204b0226d276a6989",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191451,
-    "wof:lastmodified":1566646276,
+    "wof:lastmodified":1582393023,
     "wof:name":"Urbana San Joaquin",
     "wof:parent_id":421188833,
     "wof:placetype":"localadmin",

--- a/data/421/191/453/421191453.geojson
+++ b/data/421/191/453/421191453.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e650c8322ff0cc99e53f800d6d84f03",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191453,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"Bolivar",
     "wof:parent_id":421200611,
     "wof:placetype":"localadmin",

--- a/data/421/191/455/421191455.geojson
+++ b/data/421/191/455/421191455.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c71ed117ae30718f0fd814fb11faac2",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":421191455,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"El Consejo",
     "wof:parent_id":421181777,
     "wof:placetype":"localadmin",

--- a/data/421/191/457/421191457.geojson
+++ b/data/421/191/457/421191457.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009693,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d68c678c4b850c64bf0e5462721108e0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421191457,
-    "wof:lastmodified":1566646276,
+    "wof:lastmodified":1582393023,
     "wof:name":"San Cristobal",
     "wof:parent_id":421185095,
     "wof:placetype":"localadmin",

--- a/data/421/191/753/421191753.geojson
+++ b/data/421/191/753/421191753.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009706,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b02431b9162aad4c7410af894bce390",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191753,
-    "wof:lastmodified":1566646274,
+    "wof:lastmodified":1582393023,
     "wof:name":"Tucupita",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/421/191/761/421191761.geojson
+++ b/data/421/191/761/421191761.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009707,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4284757daf3a485d9f3630b9fb94ebf",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421191761,
-    "wof:lastmodified":1566646275,
+    "wof:lastmodified":1582393023,
     "wof:name":"Obispo Ramos De Lora",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/193/013/421193013.geojson
+++ b/data/421/193/013/421193013.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009757,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a461bc05665ef478d51be0513b7716dc",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421193013,
-    "wof:lastmodified":1566646226,
+    "wof:lastmodified":1582393016,
     "wof:name":"Anaco",
     "wof:parent_id":421175071,
     "wof:placetype":"localadmin",

--- a/data/421/193/015/421193015.geojson
+++ b/data/421/193/015/421193015.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009757,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6891ea1160f9c21aa483c12125bafe86",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421193015,
-    "wof:lastmodified":1566646226,
+    "wof:lastmodified":1582393016,
     "wof:name":"Pio Tamayo",
     "wof:parent_id":421183169,
     "wof:placetype":"localadmin",

--- a/data/421/193/365/421193365.geojson
+++ b/data/421/193/365/421193365.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009768,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2321d050a20cc11a08b98147e17f5cd2",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421193365,
-    "wof:lastmodified":1566646225,
+    "wof:lastmodified":1582393016,
     "wof:name":"Arismendi",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/193/381/421193381.geojson
+++ b/data/421/193/381/421193381.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37fae29cce564808fda6bce0b43f64ad",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421193381,
-    "wof:lastmodified":1566646227,
+    "wof:lastmodified":1582393017,
     "wof:name":"Monse\u00f1or Iturriza",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/193/517/421193517.geojson
+++ b/data/421/193/517/421193517.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009774,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"297e0897d5a2476b1bf1df1e688d1c69",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421193517,
-    "wof:lastmodified":1566646226,
+    "wof:lastmodified":1582393016,
     "wof:name":"Tocopero",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/193/519/421193519.geojson
+++ b/data/421/193/519/421193519.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009774,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a594f4b574dad33fe1846d68ad956ec",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421193519,
-    "wof:lastmodified":1566646226,
+    "wof:lastmodified":1582393016,
     "wof:name":"Camatagua",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/194/073/421194073.geojson
+++ b/data/421/194/073/421194073.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"515564ca50a05b22eaefd6e3bd53b1d6",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421194073,
-    "wof:lastmodified":1566646225,
+    "wof:lastmodified":1582393016,
     "wof:name":"El Hatillo",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/194/991/421194991.geojson
+++ b/data/421/194/991/421194991.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009827,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d30c660d0f97bf2c6b23b1ceaa8434fb",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421194991,
-    "wof:lastmodified":1566646223,
+    "wof:lastmodified":1582393016,
     "wof:name":"Bolivar",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/194/993/421194993.geojson
+++ b/data/421/194/993/421194993.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009827,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13507a0a9ae8964f1e38c79b369b3716",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421194993,
-    "wof:lastmodified":1566646225,
+    "wof:lastmodified":1582393016,
     "wof:name":"Cardenal Quintero",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/194/995/421194995.geojson
+++ b/data/421/194/995/421194995.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d28b2dd09516300f726ec1dcd98ef21b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421194995,
-    "wof:lastmodified":1566646224,
+    "wof:lastmodified":1582393016,
     "wof:name":"Capital San Felipe",
     "wof:parent_id":890450031,
     "wof:placetype":"localadmin",

--- a/data/421/194/997/421194997.geojson
+++ b/data/421/194/997/421194997.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c56dd15881715ff342f9bb4b17e6a774",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421194997,
-    "wof:lastmodified":1566646223,
+    "wof:lastmodified":1582393016,
     "wof:name":"Jose Cenobio",
     "wof:parent_id":1108694415,
     "wof:placetype":"localadmin",

--- a/data/421/194/999/421194999.geojson
+++ b/data/421/194/999/421194999.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b39532e225c233d6bfa2adee164265e6",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421194999,
-    "wof:lastmodified":1566646224,
+    "wof:lastmodified":1582393016,
     "wof:name":"San Juan",
     "wof:parent_id":1108694091,
     "wof:placetype":"localadmin",

--- a/data/421/195/001/421195001.geojson
+++ b/data/421/195/001/421195001.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59ae40406f8e59cd8f6efea599302300",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":421195001,
-    "wof:lastmodified":1566646219,
+    "wof:lastmodified":1582393016,
     "wof:name":"Cocorote",
     "wof:parent_id":421172277,
     "wof:placetype":"localadmin",

--- a/data/421/195/003/421195003.geojson
+++ b/data/421/195/003/421195003.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e40e76624856c48a50d746cc2c908cdd",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195003,
-    "wof:lastmodified":1566646221,
+    "wof:lastmodified":1582393016,
     "wof:name":"Monsenor Jauregui",
     "wof:parent_id":421188083,
     "wof:placetype":"localadmin",

--- a/data/421/195/007/421195007.geojson
+++ b/data/421/195/007/421195007.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2df37e96744b2ca95d433c130529296",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421195007,
-    "wof:lastmodified":1566646219,
+    "wof:lastmodified":1582393016,
     "wof:name":"Santa Teresa",
     "wof:parent_id":1108694113,
     "wof:placetype":"localadmin",

--- a/data/421/195/009/421195009.geojson
+++ b/data/421/195/009/421195009.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f7ace0ae93a825dfdd9de94390c9f756",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195009,
-    "wof:lastmodified":1566646219,
+    "wof:lastmodified":1582393016,
     "wof:name":"Punta Cardon",
     "wof:parent_id":890451975,
     "wof:placetype":"localadmin",

--- a/data/421/195/011/421195011.geojson
+++ b/data/421/195/011/421195011.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009828,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7335d55f66de11afcee6345be710fad5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421195011,
-    "wof:lastmodified":1566646221,
+    "wof:lastmodified":1582393016,
     "wof:name":"Capital Zamora",
     "wof:parent_id":1108694179,
     "wof:placetype":"localadmin",

--- a/data/421/195/115/421195115.geojson
+++ b/data/421/195/115/421195115.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009832,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9eb8c9b4783335440271d453df7025df",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421195115,
-    "wof:lastmodified":1566646222,
+    "wof:lastmodified":1582393016,
     "wof:name":"Lobatera",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/195/121/421195121.geojson
+++ b/data/421/195/121/421195121.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009833,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0005ac67de7c55012543139db6480f3b",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421195121,
-    "wof:lastmodified":1566646221,
+    "wof:lastmodified":1582393016,
     "wof:name":"Calderas",
     "wof:parent_id":421194991,
     "wof:placetype":"localadmin",

--- a/data/421/195/493/421195493.geojson
+++ b/data/421/195/493/421195493.geojson
@@ -352,6 +352,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7a2d9747e95012ccfbc89d30ee31b4e",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         }
     ],
     "wof:id":421195493,
-    "wof:lastmodified":1566646221,
+    "wof:lastmodified":1582393016,
     "wof:name":"Torbes",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/195/495/421195495.geojson
+++ b/data/421/195/495/421195495.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4197636f557e1a41d714c819507424cc",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421195495,
-    "wof:lastmodified":1566646222,
+    "wof:lastmodified":1582393016,
     "wof:name":"Juan Jose Mora",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/195/497/421195497.geojson
+++ b/data/421/195/497/421195497.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"95af5190357dcc9fe8476de6a7a24b19",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421195497,
-    "wof:lastmodified":1566646219,
+    "wof:lastmodified":1582393016,
     "wof:name":"Infante",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/421/195/501/421195501.geojson
+++ b/data/421/195/501/421195501.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ea702ffafe90e0ec8f52e9c725502c3",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421195501,
-    "wof:lastmodified":1566646221,
+    "wof:lastmodified":1582393016,
     "wof:name":"Francisco Linares Alcantara",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/195/503/421195503.geojson
+++ b/data/421/195/503/421195503.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd8a580f2d40f837a77b7a624e5e399b",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421195503,
-    "wof:lastmodified":1566646218,
+    "wof:lastmodified":1582393016,
     "wof:name":"Bolivar",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/195/505/421195505.geojson
+++ b/data/421/195/505/421195505.geojson
@@ -208,6 +208,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009850,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29896640bb9fc6e38ef62faeebf0b247",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":421195505,
-    "wof:lastmodified":1566646218,
+    "wof:lastmodified":1582393015,
     "wof:name":"Francisco De Miranda",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/195/639/421195639.geojson
+++ b/data/421/195/639/421195639.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009854,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ce31ebc9a228d94c4dc22d8376eafed",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421195639,
-    "wof:lastmodified":1566646222,
+    "wof:lastmodified":1582393016,
     "wof:name":"Camaguan",
     "wof:parent_id":1108694141,
     "wof:placetype":"localadmin",

--- a/data/421/196/155/421196155.geojson
+++ b/data/421/196/155/421196155.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009871,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f17c00e492f6cb075752544479ce863d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421196155,
-    "wof:lastmodified":1566646272,
+    "wof:lastmodified":1582393023,
     "wof:name":"Guaraque",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/196/339/421196339.geojson
+++ b/data/421/196/339/421196339.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009878,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"832b57c7441925c6e3c34592f423edd2",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":421196339,
-    "wof:lastmodified":1566646270,
+    "wof:lastmodified":1582393022,
     "wof:name":"Santa Maria de Ipire",
     "wof:parent_id":1108694413,
     "wof:placetype":"localadmin",

--- a/data/421/196/541/421196541.geojson
+++ b/data/421/196/541/421196541.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db69711d7749d41a35dab29f24c3174e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421196541,
-    "wof:lastmodified":1566646273,
+    "wof:lastmodified":1582393023,
     "wof:name":"Chiguara",
     "wof:parent_id":1108694437,
     "wof:placetype":"localadmin",

--- a/data/421/196/543/421196543.geojson
+++ b/data/421/196/543/421196543.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7bc38b9b894705be7da203d5998c747",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421196543,
-    "wof:lastmodified":1566646271,
+    "wof:lastmodified":1582393023,
     "wof:name":"Antonio Diaz",
     "wof:parent_id":1108694453,
     "wof:placetype":"localadmin",

--- a/data/421/196/555/421196555.geojson
+++ b/data/421/196/555/421196555.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a383988e25736be5dd2d6b6e85a94e56",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421196555,
-    "wof:lastmodified":1566646271,
+    "wof:lastmodified":1582393023,
     "wof:name":"Chacanta",
     "wof:parent_id":421175381,
     "wof:placetype":"localadmin",

--- a/data/421/196/939/421196939.geojson
+++ b/data/421/196/939/421196939.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6947ff7d59af5f8d69b17e60b2cb262",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421196939,
-    "wof:lastmodified":1566646270,
+    "wof:lastmodified":1582393022,
     "wof:name":"Cardenas",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/196/977/421196977.geojson
+++ b/data/421/196/977/421196977.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02d6ec6db86e72e629322d83dff00033",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421196977,
-    "wof:lastmodified":1566646270,
+    "wof:lastmodified":1582393022,
     "wof:name":"Mara",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/196/979/421196979.geojson
+++ b/data/421/196/979/421196979.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44e63a114670f00329bf39728ee9a5e5",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421196979,
-    "wof:lastmodified":1566646271,
+    "wof:lastmodified":1582393022,
     "wof:name":"Cede\u00f1o",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/196/981/421196981.geojson
+++ b/data/421/196/981/421196981.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4dc19b86b282b596df8107a6d280ea72",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421196981,
-    "wof:lastmodified":1566646273,
+    "wof:lastmodified":1582393023,
     "wof:name":"Raul Leoni",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/196/983/421196983.geojson
+++ b/data/421/196/983/421196983.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45c95be9ae2d849c0d75114bd497baa9",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421196983,
-    "wof:lastmodified":1566646271,
+    "wof:lastmodified":1582393022,
     "wof:name":"Marcano",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/196/987/421196987.geojson
+++ b/data/421/196/987/421196987.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dde0a739cc66bb0bc6a33b0f1fc2dbee",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421196987,
-    "wof:lastmodified":1566646272,
+    "wof:lastmodified":1582393023,
     "wof:name":"Capital Michelena",
     "wof:parent_id":1108694287,
     "wof:placetype":"localadmin",

--- a/data/421/196/989/421196989.geojson
+++ b/data/421/196/989/421196989.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1147b54b37e56be64231fc448657caad",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421196989,
-    "wof:lastmodified":1566646273,
+    "wof:lastmodified":1582393023,
     "wof:name":"Capital Libertad",
     "wof:parent_id":1108694213,
     "wof:placetype":"localadmin",

--- a/data/421/196/991/421196991.geojson
+++ b/data/421/196/991/421196991.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9bd553295d14982a6cda5e99707667d7",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421196991,
-    "wof:lastmodified":1566646270,
+    "wof:lastmodified":1582393022,
     "wof:name":"Caucagua",
     "wof:parent_id":421166897,
     "wof:placetype":"localadmin",

--- a/data/421/196/993/421196993.geojson
+++ b/data/421/196/993/421196993.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009899,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18d267918579c1ef8db10f0089b6419a",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421196993,
-    "wof:lastmodified":1566646272,
+    "wof:lastmodified":1582393023,
     "wof:name":"Matriz",
     "wof:parent_id":1108694253,
     "wof:placetype":"localadmin",

--- a/data/421/197/137/421197137.geojson
+++ b/data/421/197/137/421197137.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4723a42fab37a63dbe543d620958c7a7",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421197137,
-    "wof:lastmodified":1566646279,
+    "wof:lastmodified":1582393024,
     "wof:name":"Cabudare",
     "wof:parent_id":1108694327,
     "wof:placetype":"localadmin",

--- a/data/421/197/139/421197139.geojson
+++ b/data/421/197/139/421197139.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9897ce0b58839aca79677dc7abcfe34",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421197139,
-    "wof:lastmodified":1566646279,
+    "wof:lastmodified":1582393024,
     "wof:name":"Ocumare de la Costa",
     "wof:parent_id":421188835,
     "wof:placetype":"localadmin",

--- a/data/421/197/141/421197141.geojson
+++ b/data/421/197/141/421197141.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009904,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fee3d1e6c8f903b271aa2c008a61fcd9",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":421197141,
-    "wof:lastmodified":1566646280,
+    "wof:lastmodified":1582393024,
     "wof:name":"Chuao",
     "wof:parent_id":421186263,
     "wof:placetype":"localadmin",

--- a/data/421/197/623/421197623.geojson
+++ b/data/421/197/623/421197623.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009919,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0502e6d65d3c55aee4ee1b40dead28e3",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421197623,
-    "wof:lastmodified":1566646279,
+    "wof:lastmodified":1582393024,
     "wof:name":"Piar",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/198/089/421198089.geojson
+++ b/data/421/198/089/421198089.geojson
@@ -237,6 +237,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009936,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e1e31c855b29214299dd8ec377dc3a9",
     "wof:hierarchy":[
         {
@@ -247,7 +250,7 @@
         }
     ],
     "wof:id":421198089,
-    "wof:lastmodified":1566646268,
+    "wof:lastmodified":1582393022,
     "wof:name":"Puerto Cabello",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/198/671/421198671.geojson
+++ b/data/421/198/671/421198671.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009956,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a224ad3cd947428978eaf641c68a3c44",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421198671,
-    "wof:lastmodified":1566646269,
+    "wof:lastmodified":1582393022,
     "wof:name":"Sifontes",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/199/283/421199283.geojson
+++ b/data/421/199/283/421199283.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459009984,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1cb0d6b60b6692a4561b85ece51f3633",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421199283,
-    "wof:lastmodified":1566646280,
+    "wof:lastmodified":1582393024,
     "wof:name":"Puerto la Cruz",
     "wof:parent_id":421204791,
     "wof:placetype":"localadmin",

--- a/data/421/199/913/421199913.geojson
+++ b/data/421/199/913/421199913.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010005,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c61f0253c86c65e014df7c89d3440273",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421199913,
-    "wof:lastmodified":1566646280,
+    "wof:lastmodified":1582393024,
     "wof:name":"Capital Santiago Mari\u00f1o",
     "wof:parent_id":421186263,
     "wof:placetype":"localadmin",

--- a/data/421/200/093/421200093.geojson
+++ b/data/421/200/093/421200093.geojson
@@ -168,6 +168,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010011,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f790dc2a6a20494f588c99b85721fa6",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421200093,
-    "wof:lastmodified":1566646281,
+    "wof:lastmodified":1582393024,
     "wof:name":"San Carlos",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/421/200/611/421200611.geojson
+++ b/data/421/200/611/421200611.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010031,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"903ae1700b0c208b96400b799cecafcb",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421200611,
-    "wof:lastmodified":1566646281,
+    "wof:lastmodified":1582393024,
     "wof:name":"Moran",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/201/173/421201173.geojson
+++ b/data/421/201/173/421201173.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010064,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c71c7fdcfe4fee6b53465cf9ce05302d",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421201173,
-    "wof:lastmodified":1578434366,
+    "wof:lastmodified":1582393024,
     "wof:name":"Atures",
     "wof:parent_id":1511838383,
     "wof:placetype":"localadmin",

--- a/data/421/201/567/421201567.geojson
+++ b/data/421/201/567/421201567.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8fa02266e8b208c774215f262153aee",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421201567,
-    "wof:lastmodified":1566646282,
+    "wof:lastmodified":1582393024,
     "wof:name":"Paez",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/201/571/421201571.geojson
+++ b/data/421/201/571/421201571.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bda44d7289aaed30bafeac7861172cad",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421201571,
-    "wof:lastmodified":1566646284,
+    "wof:lastmodified":1582393025,
     "wof:name":"Simon Bolivar",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/201/579/421201579.geojson
+++ b/data/421/201/579/421201579.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010077,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca5b091002c44491756fe4761bd28ec8",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421201579,
-    "wof:lastmodified":1566646284,
+    "wof:lastmodified":1582393025,
     "wof:name":"Rio Caribe",
     "wof:parent_id":421193365,
     "wof:placetype":"localadmin",

--- a/data/421/201/655/421201655.geojson
+++ b/data/421/201/655/421201655.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010080,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"358b4296d096856e26ba5586f12a03c3",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421201655,
-    "wof:lastmodified":1566646283,
+    "wof:lastmodified":1582393024,
     "wof:name":"Santa Barbara",
     "wof:parent_id":421186435,
     "wof:placetype":"localadmin",

--- a/data/421/202/057/421202057.geojson
+++ b/data/421/202/057/421202057.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010103,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44505d9dc885e4a49d6261a53eee6b5d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421202057,
-    "wof:lastmodified":1566646237,
+    "wof:lastmodified":1582393018,
     "wof:name":"Paez",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/421/202/059/421202059.geojson
+++ b/data/421/202/059/421202059.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010103,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4cfee455c0fc25a2c76e692cd23cc3b1",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421202059,
-    "wof:lastmodified":1566646236,
+    "wof:lastmodified":1582393018,
     "wof:name":"Cabimas",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/202/063/421202063.geojson
+++ b/data/421/202/063/421202063.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010103,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"783feab62b41df3153117fc001754327",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
         }
     ],
     "wof:id":421202063,
-    "wof:lastmodified":1566646235,
+    "wof:lastmodified":1582393017,
     "wof:name":"Zamora",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/202/065/421202065.geojson
+++ b/data/421/202/065/421202065.geojson
@@ -340,6 +340,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010103,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"839242a8b82f03613da0c4485c00befb",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         }
     ],
     "wof:id":421202065,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Jose Maria Vargas",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/202/067/421202067.geojson
+++ b/data/421/202/067/421202067.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010103,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5458885804ef7da38e3095cc5402d46",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421202067,
-    "wof:lastmodified":1566646237,
+    "wof:lastmodified":1582393018,
     "wof:name":"Jauregui",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/202/069/421202069.geojson
+++ b/data/421/202/069/421202069.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010104,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"922989933927b67deced9395b92cfb2f",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421202069,
-    "wof:lastmodified":1566646237,
+    "wof:lastmodified":1582393018,
     "wof:name":"Gomez",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/202/093/421202093.geojson
+++ b/data/421/202/093/421202093.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010105,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc5fe877de8600c74d7fa97802ff512f",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421202093,
-    "wof:lastmodified":1566646237,
+    "wof:lastmodified":1582393018,
     "wof:name":"Rubio",
     "wof:parent_id":421203511,
     "wof:placetype":"locality",

--- a/data/421/202/369/421202369.geojson
+++ b/data/421/202/369/421202369.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4d9a7c1fa85fadac5c10bb6b665c167",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421202369,
-    "wof:lastmodified":1566646235,
+    "wof:lastmodified":1582393018,
     "wof:name":"Gran Sabana",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/202/371/421202371.geojson
+++ b/data/421/202/371/421202371.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43311f3bbf831ee9d989c80f0b49e725",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421202371,
-    "wof:lastmodified":1566646235,
+    "wof:lastmodified":1582393018,
     "wof:name":"Roscio",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/202/373/421202373.geojson
+++ b/data/421/202/373/421202373.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010115,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c879d9ca6dbeb653878a3add0c4b9d6f",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421202373,
-    "wof:lastmodified":1566646237,
+    "wof:lastmodified":1582393018,
     "wof:name":"Valencia",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/202/375/421202375.geojson
+++ b/data/421/202/375/421202375.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010116,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34fa59609d400eb9ac539b5f3542a564",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421202375,
-    "wof:lastmodified":1566646238,
+    "wof:lastmodified":1582393018,
     "wof:name":"Guaicaipuro",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/202/591/421202591.geojson
+++ b/data/421/202/591/421202591.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72d435d9ffb32f09baca443a96ebaf7a",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421202591,
-    "wof:lastmodified":1566646236,
+    "wof:lastmodified":1582393018,
     "wof:name":"Libertador",
     "wof:parent_id":85680535,
     "wof:placetype":"county",

--- a/data/421/202/593/421202593.geojson
+++ b/data/421/202/593/421202593.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f10f05c670fc8d8b435adb3db69fb9d",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421202593,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Mu\u00f1oz",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/202/595/421202595.geojson
+++ b/data/421/202/595/421202595.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b1cd2a7d257f37ac065026c47f192ac",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421202595,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Idelfonso Vasquez",
     "wof:parent_id":421172589,
     "wof:placetype":"localadmin",

--- a/data/421/202/603/421202603.geojson
+++ b/data/421/202/603/421202603.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1890d7bba6c09775314e7eef91664c1f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421202603,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Pueblo Nuevo del Sur",
     "wof:parent_id":421171999,
     "wof:placetype":"localadmin",

--- a/data/421/202/605/421202605.geojson
+++ b/data/421/202/605/421202605.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010123,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6839875256e8a0e93e037ded037cfb9b",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421202605,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Chichiriviche",
     "wof:parent_id":421193381,
     "wof:placetype":"localadmin",

--- a/data/421/202/707/421202707.geojson
+++ b/data/421/202/707/421202707.geojson
@@ -55,6 +55,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010127,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"651b993c19140c6de4ad90ae53853c5c",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421202707,
-    "wof:lastmodified":1566646234,
+    "wof:lastmodified":1582393017,
     "wof:name":"Capital Sucre",
     "wof:parent_id":1108694433,
     "wof:placetype":"localadmin",

--- a/data/421/203/373/421203373.geojson
+++ b/data/421/203/373/421203373.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010149,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10008119ddc846f5fe5b311786a78dc9",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421203373,
-    "wof:lastmodified":1566646233,
+    "wof:lastmodified":1582393017,
     "wof:name":"Bolivar",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/203/511/421203511.geojson
+++ b/data/421/203/511/421203511.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010155,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1768efd2e34bdb661de0a6df1d00ff91",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421203511,
-    "wof:lastmodified":1566646231,
+    "wof:lastmodified":1582393017,
     "wof:name":"Junin",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/203/565/421203565.geojson
+++ b/data/421/203/565/421203565.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"220201e8a1f6fd7af53070f7f5ff1188",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":421203565,
-    "wof:lastmodified":1566646231,
+    "wof:lastmodified":1582393017,
     "wof:name":"Sosa",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/203/571/421203571.geojson
+++ b/data/421/203/571/421203571.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"358252900261c7d02792a31aa2cdca0e",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421203571,
-    "wof:lastmodified":1566646232,
+    "wof:lastmodified":1582393017,
     "wof:name":"Independencia",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/204/299/421204299.geojson
+++ b/data/421/204/299/421204299.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8efc9574c85afedd86cb2389637e4da8",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421204299,
-    "wof:lastmodified":1566646229,
+    "wof:lastmodified":1582393017,
     "wof:name":"Paez",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/204/789/421204789.geojson
+++ b/data/421/204/789/421204789.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010198,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4acd6fae6946e6f255ec9b3b02b784e",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421204789,
-    "wof:lastmodified":1566646230,
+    "wof:lastmodified":1582393017,
     "wof:name":"San Felipe",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/204/791/421204791.geojson
+++ b/data/421/204/791/421204791.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010198,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08c9dee17f705fd5fd18686b952034ee",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421204791,
-    "wof:lastmodified":1566646228,
+    "wof:lastmodified":1582393017,
     "wof:name":"Sotillo",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/205/039/421205039.geojson
+++ b/data/421/205/039/421205039.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"VE",
     "wof:created":1459010210,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d3a536aea4130d9daa59383873e3033",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":421205039,
-    "wof:lastmodified":1566646238,
+    "wof:lastmodified":1582393018,
     "wof:name":"Manicuare",
     "wof:parent_id":421172601,
     "wof:placetype":"localadmin",

--- a/data/856/323/17/85632317.geojson
+++ b/data/856/323/17/85632317.geojson
@@ -1007,7 +1007,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1062,6 +1063,11 @@
     },
     "wof:country":"VE",
     "wof:country_alpha3":"VEN",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"646b2b95f5542d527961379040dddc41",
     "wof:hierarchy":[
         {
@@ -1076,7 +1082,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644710,
+    "wof:lastmodified":1582392994,
     "wof:name":"Venezuela",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/323/17/85632317.geojson
+++ b/data/856/323/17/85632317.geojson
@@ -1007,8 +1007,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1082,7 +1081,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582392994,
+    "wof:lastmodified":1583271275,
     "wof:name":"Venezuela",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/804/61/85680461.geojson
+++ b/data/856/804/61/85680461.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Falc\u00f3n"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"411706457a7a0d93dee0fa78190c5016",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644697,
+    "wof:lastmodified":1582392987,
     "wof:name":"Falc\u00f3n",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/65/85680465.geojson
+++ b/data/856/804/65/85680465.geojson
@@ -367,6 +367,9 @@
         "wk:page":"Apure"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d06017f3b95e897700da84bc3ef4987",
     "wof:hierarchy":[
         {
@@ -382,7 +385,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644700,
+    "wof:lastmodified":1582392989,
     "wof:name":"Apure",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/69/85680469.geojson
+++ b/data/856/804/69/85680469.geojson
@@ -354,6 +354,9 @@
         "wk:page":"Barinas (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"deebd4ef9f546d4dae0d1e255385e3b1",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644698,
+    "wof:lastmodified":1582392987,
     "wof:name":"Barinas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/73/85680473.geojson
+++ b/data/856/804/73/85680473.geojson
@@ -345,6 +345,9 @@
         "wk:page":"M\u00e9rida (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc84460692b1d2b5cbfc438dd9866355",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644698,
+    "wof:lastmodified":1582392988,
     "wof:name":"M\u00e9rida",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/81/85680481.geojson
+++ b/data/856/804/81/85680481.geojson
@@ -353,6 +353,9 @@
         "wk:page":"T\u00e1chira"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e480ff4b498be593c5a482a8d6d090f",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644699,
+    "wof:lastmodified":1582392988,
     "wof:name":"T\u00e1chira",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/83/85680483.geojson
+++ b/data/856/804/83/85680483.geojson
@@ -339,6 +339,9 @@
         "wk:page":"Trujillo (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f4325263382b3e661eb06ddadedfb8c",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644701,
+    "wof:lastmodified":1582392989,
     "wof:name":"Trujillo",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/87/85680487.geojson
+++ b/data/856/804/87/85680487.geojson
@@ -369,6 +369,9 @@
         "wk:page":"Zulia"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f832c3e642977663e087200ed755de12",
     "wof:hierarchy":[
         {
@@ -384,7 +387,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644699,
+    "wof:lastmodified":1582392988,
     "wof:name":"Zulia",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/91/85680491.geojson
+++ b/data/856/804/91/85680491.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Cojedes (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ecdc182de40910a93795b8fedcdb63e",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644700,
+    "wof:lastmodified":1582392989,
     "wof:name":"Cojedes",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/93/85680493.geojson
+++ b/data/856/804/93/85680493.geojson
@@ -358,6 +358,9 @@
         "wk:page":"Carabobo"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d504b3a71575ed8c9f04195d500ec85c",
     "wof:hierarchy":[
         {
@@ -373,7 +376,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644698,
+    "wof:lastmodified":1582392988,
     "wof:name":"Carabobo",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/99/85680499.geojson
+++ b/data/856/804/99/85680499.geojson
@@ -337,6 +337,9 @@
         "wk:page":"Lara (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b77ee2a4d659dc38edabb91c3ffc19b",
     "wof:hierarchy":[
         {
@@ -352,7 +355,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644701,
+    "wof:lastmodified":1582392989,
     "wof:name":"Lara",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/03/85680503.geojson
+++ b/data/856/805/03/85680503.geojson
@@ -330,6 +330,9 @@
         "wk:page":"Portuguesa (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d60a4834028c2e23406359d575496db9",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644702,
+    "wof:lastmodified":1582392990,
     "wof:name":"Portuguesa",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/07/85680507.geojson
+++ b/data/856/805/07/85680507.geojson
@@ -331,6 +331,9 @@
         "wk:page":"Yaracuy"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c22e86c1a1bec54e372c73cddf0f94ec",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644707,
+    "wof:lastmodified":1582392992,
     "wof:name":"Yaracuy",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/11/85680511.geojson
+++ b/data/856/805/11/85680511.geojson
@@ -375,6 +375,9 @@
         "wk:page":"Amazonas (Venezuelan state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f2e75046ebf061cac91d4f3c6b9191e",
     "wof:hierarchy":[
         {
@@ -390,7 +393,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644703,
+    "wof:lastmodified":1582392990,
     "wof:name":"Amazonas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/17/85680517.geojson
+++ b/data/856/805/17/85680517.geojson
@@ -363,6 +363,9 @@
         "wk:page":"Bol\u00edvar (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f566a8a4ed56193133bf1634844a004",
     "wof:hierarchy":[
         {
@@ -378,7 +381,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644704,
+    "wof:lastmodified":1582392991,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/21/85680521.geojson
+++ b/data/856/805/21/85680521.geojson
@@ -356,6 +356,9 @@
         "wk:page":"Anzo\u00e1tegui"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cf87be387bee5cad9258a9425395f8e",
     "wof:hierarchy":[
         {
@@ -371,7 +374,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644706,
+    "wof:lastmodified":1582392992,
     "wof:name":"Anzo\u00e1tegui",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/25/85680525.geojson
+++ b/data/856/805/25/85680525.geojson
@@ -370,6 +370,9 @@
         "wk:page":"Aragua"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40221c7f37070e1bba020abf68d3c03d",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644709,
+    "wof:lastmodified":1582392993,
     "wof:name":"Aragua",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/33/85680533.geojson
+++ b/data/856/805/33/85680533.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Vargas (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29f6d27de444f73257f0c392f07b3ef4",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644703,
+    "wof:lastmodified":1582392990,
     "wof:name":"Vargas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/35/85680535.geojson
+++ b/data/856/805/35/85680535.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Capital District (Venezuela)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03fdb20863219db8351adf114fa3b250",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644703,
+    "wof:lastmodified":1582392990,
     "wof:name":"Distrito Capital",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/39/85680539.geojson
+++ b/data/856/805/39/85680539.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Federal Dependencies of Venezuela"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ec588f1c0e614d891dc85afa33d1536",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644708,
+    "wof:lastmodified":1582392993,
     "wof:name":"Dependencias Federales",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/43/85680543.geojson
+++ b/data/856/805/43/85680543.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Gu\u00e1rico"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e51a98ca1a904d401edfa3bbd9f9826b",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644707,
+    "wof:lastmodified":1582392992,
     "wof:name":"Gu\u00e1rico",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/47/85680547.geojson
+++ b/data/856/805/47/85680547.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Monagas"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97a741ebac38a4e3484603dc32e973e7",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644708,
+    "wof:lastmodified":1582392993,
     "wof:name":"Monagas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/53/85680553.geojson
+++ b/data/856/805/53/85680553.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Miranda (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f5f86a5a1b9709f7b5b8cb3a4bd4751",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644708,
+    "wof:lastmodified":1582392992,
     "wof:name":"Miranda",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/57/85680557.geojson
+++ b/data/856/805/57/85680557.geojson
@@ -350,6 +350,9 @@
         "wk:page":"Nueva Esparta"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a198824fba9841ff8b2cc4b1970ec85f",
     "wof:hierarchy":[
         {
@@ -365,7 +368,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644702,
+    "wof:lastmodified":1582392990,
     "wof:name":"Nueva Esparta",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/61/85680561.geojson
+++ b/data/856/805/61/85680561.geojson
@@ -347,6 +347,9 @@
         "wk:page":"Sucre (state)"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"201142bcb9d001be9d84800318f58796",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644702,
+    "wof:lastmodified":1582392989,
     "wof:name":"Sucre",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/65/85680565.geojson
+++ b/data/856/805/65/85680565.geojson
@@ -357,6 +357,9 @@
         "wk:page":"Delta Amacuro"
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3061287a5f5f38238f45dc17ffcf66d",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644707,
+    "wof:lastmodified":1582392992,
     "wof:name":"Delta Amacuro",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/857/649/63/85764963.geojson
+++ b/data/857/649/63/85764963.geojson
@@ -80,6 +80,9 @@
         "qs:id":1082765
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78cb7dbbeb3bffea036d68376f6e9058",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379807,
+    "wof:lastmodified":1582392986,
     "wof:name":"Cotorrera",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/67/85764967.geojson
+++ b/data/857/649/67/85764967.geojson
@@ -103,6 +103,9 @@
         "qs_pg:id":235289
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7378b3a33813c82a1e9aee3f680c7400",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644696,
+    "wof:lastmodified":1582392986,
     "wof:name":"El Silencio",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/73/85764973.geojson
+++ b/data/857/649/73/85764973.geojson
@@ -111,6 +111,9 @@
         "qs:id":489670
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b9c43f1e895f7532b50890e774977fd",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379806,
+    "wof:lastmodified":1582392986,
     "wof:name":"La Carlota",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/77/85764977.geojson
+++ b/data/857/649/77/85764977.geojson
@@ -88,6 +88,9 @@
         "qs_pg:id":1082767
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"218c389da1002ab4611eb04fda7ccb2e",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644697,
+    "wof:lastmodified":1582392987,
     "wof:name":"La Pastora",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/81/85764981.geojson
+++ b/data/857/649/81/85764981.geojson
@@ -75,6 +75,9 @@
         "qs:id":1082769
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a42a1337450cf7bca76a6543173e4546",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379806,
+    "wof:lastmodified":1582392986,
     "wof:name":"Las Flores",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/83/85764983.geojson
+++ b/data/857/649/83/85764983.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":211193
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cf17837025b8a166699fe6598730f6d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644697,
+    "wof:lastmodified":1582392986,
     "wof:name":"Llano de Miquil\u00e9n",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/89/85764989.geojson
+++ b/data/857/649/89/85764989.geojson
@@ -80,6 +80,9 @@
         "qs:id":489671
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37f0243880ed542581deaacf3f4fa62e",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379807,
+    "wof:lastmodified":1582392986,
     "wof:name":"Los Caobas",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/47/85765547.geojson
+++ b/data/857/655/47/85765547.geojson
@@ -75,6 +75,9 @@
         "qs:id":1165495
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4467f3178621389eb37a2afdf5733cb4",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379806,
+    "wof:lastmodified":1582392987,
     "wof:name":"La Concordia",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/51/85765551.geojson
+++ b/data/857/655/51/85765551.geojson
@@ -130,6 +130,9 @@
         "qs_pg:id":1342598
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"169aff9a5d1ef89c0f394a41f6c42d00",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644697,
+    "wof:lastmodified":1582392987,
     "wof:name":"San F\u00e9lix",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/17/85794117.geojson
+++ b/data/857/941/17/85794117.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":277839
     },
     "wof:country":"VE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f069f2b26e8c3f61b56b999d2bf84c5",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644696,
+    "wof:lastmodified":1582392986,
     "wof:name":"Barrio Andr\u00e9s Eloy Blanco",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/417/393/890417393.geojson
+++ b/data/890/417/393/890417393.geojson
@@ -712,6 +712,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469051199,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efc15ea98d1d38f9ebff55f3d03eed46",
     "wof:hierarchy":[
         {
@@ -722,7 +725,7 @@
         }
     ],
     "wof:id":890417393,
-    "wof:lastmodified":1566646310,
+    "wof:lastmodified":1582393028,
     "wof:name":"Silva",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/890/420/047/890420047.geojson
+++ b/data/890/420/047/890420047.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469051314,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f9b2db472ef539295d40faa01f6a9ab",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":890420047,
-    "wof:lastmodified":1566646311,
+    "wof:lastmodified":1582393028,
     "wof:name":"Alto Orinoco",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/890/429/493/890429493.geojson
+++ b/data/890/429/493/890429493.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469051816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e62ba1169c82210bf20f86ad10d8af54",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":890429493,
-    "wof:lastmodified":1566646310,
+    "wof:lastmodified":1582393028,
     "wof:name":"Barinas",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/890/439/859/890439859.geojson
+++ b/data/890/439/859/890439859.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052252,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9b09a199478f483011ca0183ebb74c2",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890439859,
-    "wof:lastmodified":1566646308,
+    "wof:lastmodified":1582393028,
     "wof:name":"Pampanito",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/890/440/759/890440759.geojson
+++ b/data/890/440/759/890440759.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052296,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5018e96f1c2c9c342f1471b0c315500",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890440759,
-    "wof:lastmodified":1566646306,
+    "wof:lastmodified":1582393028,
     "wof:name":"Peninsula De Macanao",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/890/441/467/890441467.geojson
+++ b/data/890/441/467/890441467.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e1bd2122752fabd264f528a8e40b117",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890441467,
-    "wof:lastmodified":1566646308,
+    "wof:lastmodified":1582393028,
     "wof:name":"Tubores",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/890/442/023/890442023.geojson
+++ b/data/890/442/023/890442023.geojson
@@ -82,6 +82,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052347,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c5b978e00e61bc1975d892a80695b75",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890442023,
-    "wof:lastmodified":1566646312,
+    "wof:lastmodified":1582393028,
     "wof:name":"Los Taques",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/890/442/127/890442127.geojson
+++ b/data/890/442/127/890442127.geojson
@@ -287,6 +287,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052351,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9054355773bfbf9ba5e2639c2e7a6f02",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":890442127,
-    "wof:lastmodified":1566646312,
+    "wof:lastmodified":1582393028,
     "wof:name":"San Felipe",
     "wof:parent_id":890450031,
     "wof:placetype":"locality",

--- a/data/890/442/147/890442147.geojson
+++ b/data/890/442/147/890442147.geojson
@@ -647,6 +647,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052351,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"9c0870f73b1c024ff1a8c0f4425fe4c9",
     "wof:hierarchy":[
         {
@@ -658,7 +661,7 @@
         }
     ],
     "wof:id":890442147,
-    "wof:lastmodified":1566646314,
+    "wof:lastmodified":1582393028,
     "wof:name":"Caracas",
     "wof:parent_id":1108694107,
     "wof:placetype":"locality",

--- a/data/890/450/029/890450029.geojson
+++ b/data/890/450/029/890450029.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052721,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"846ad23bb83bab03d1b6fc23b2d5c895",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":890450029,
-    "wof:lastmodified":1566646315,
+    "wof:lastmodified":1582393028,
     "wof:name":"Carvajal",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/890/450/031/890450031.geojson
+++ b/data/890/450/031/890450031.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052721,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e45fe664f0053bd03243243c9ea3fa7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":890450031,
-    "wof:lastmodified":1566646315,
+    "wof:lastmodified":1582393028,
     "wof:name":"Independencia",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/890/451/975/890451975.geojson
+++ b/data/890/451/975/890451975.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"VE",
     "wof:created":1469052800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce65b315d8f02f8d1c13abd5991e4a0d",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":890451975,
-    "wof:lastmodified":1566646314,
+    "wof:lastmodified":1582393028,
     "wof:name":"Carirubana",
     "wof:parent_id":85680461,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.