### PR TITLE
ve concordances, placetype local, and more

### DIFF
--- a/data/110/869/405/9/1108694059.geojson
+++ b/data/110/869/405/9/1108694059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038365,
-    "geom:area_square_m":467013978.45226,
+    "geom:area_square_m":467013966.628466,
     "geom:bbox":"-63.921459,10.023567,-63.571093,10.225365",
     "geom:latitude":10.114188,
     "geom:longitude":-63.728179,
@@ -105,9 +105,10 @@
         "hasc:id":"VE.FA.AC",
         "wd:id":"Q2823425"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415468,
-    "wof:geomhash":"688c0d37f76556a21147508e24f5bf4b",
+    "wof:geomhash":"dca6747edf2df0205c6cd38a1501ccf8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108694059,
-    "wof:lastmodified":1690915018,
+    "wof:lastmodified":1695886379,
     "wof:name":"Acosta",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/406/3/1108694063.geojson
+++ b/data/110/869/406/3/1108694063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0187,
-    "geom:area_square_m":227988832.238672,
+    "geom:area_square_m":227988832.238619,
     "geom:bbox":"-69.17669906,9.51029348055,-68.9570337121,9.70935149384",
     "geom:latitude":9.611912,
     "geom:longitude":-69.069276,
@@ -87,9 +87,10 @@
         "hasc:id":"VE.PO.AR",
         "wd:id":"Q2741347"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415470,
-    "wof:geomhash":"4f0d1921a4d863e486be22a156b9da2a",
+    "wof:geomhash":"3a2beaab199e10bfaff37517351a445c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108694063,
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1695886371,
     "wof:name":"Agua Blanca",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/406/5/1108694065.geojson
+++ b/data/110/869/406/5/1108694065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204605,
-    "geom:area_square_m":2496677350.471467,
+    "geom:area_square_m":2496677628.82152,
     "geom:bbox":"-63.971872,8.985304,-63.319415,9.549186",
     "geom:latitude":9.306728,
     "geom:longitude":-63.632548,
@@ -122,9 +122,10 @@
         "hasc:id":"VE.MO.AG",
         "wd:id":"Q2012193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415471,
-    "wof:geomhash":"d305c343d08e1aff9aba973515b7d364",
+    "wof:geomhash":"bc50b98028ddb2788c67a92983c00484",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108694065,
-    "wof:lastmodified":1690914991,
+    "wof:lastmodified":1695886371,
     "wof:name":"Aguasay",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/406/7/1108694067.geojson
+++ b/data/110/869/406/7/1108694067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009495,
-    "geom:area_square_m":115236929.993389,
+    "geom:area_square_m":115237102.522826,
     "geom:bbox":"-71.793917,10.94875,-71.530441,11.11563",
     "geom:latitude":11.023843,
     "geom:longitude":-71.693541,
@@ -100,9 +100,10 @@
         "hasc:id":"VE.ZU.AP",
         "wd:id":"Q2306582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415473,
-    "wof:geomhash":"b9a2407489597160abcc0c92ee01ca57",
+    "wof:geomhash":"d10d0440f34ae48a31f0c45debc46381",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108694067,
-    "wof:lastmodified":1690914990,
+    "wof:lastmodified":1695886371,
     "wof:name":"Almirante Padilla",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/406/9/1108694069.geojson
+++ b/data/110/869/406/9/1108694069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010157,
-    "geom:area_square_m":123571394.236073,
+    "geom:area_square_m":123571128.705586,
     "geom:bbox":"-66.100935,10.2075,-65.981769,10.383138",
     "geom:latitude":10.289469,
     "geom:longitude":-66.032359,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.ME.AB",
         "wd:id":"Q2171229"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415477,
-    "wof:geomhash":"3d1022b68d744a9594fca26afaf0a90f",
+    "wof:geomhash":"49c0cf830ab43251edca7dda83369465",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694069,
-    "wof:lastmodified":1690914990,
+    "wof:lastmodified":1695886371,
     "wof:name":"Andres Bello",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/407/1/1108694071.geojson
+++ b/data/110/869/407/1/1108694071.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.ME.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415478,
     "wof:geomhash":"c3d534164b2a7d0d76118f4b74cd3d1a",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694071,
-    "wof:lastmodified":1694492826,
+    "wof:lastmodified":1695886250,
     "wof:name":"Andres Bello",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/407/3/1108694073.geojson
+++ b/data/110/869/407/3/1108694073.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.ME.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415480,
     "wof:geomhash":"4388d8cfd058a70ead297382f5f177fc",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694073,
-    "wof:lastmodified":1694492826,
+    "wof:lastmodified":1695886250,
     "wof:name":"Andres Bello",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/407/5/1108694075.geojson
+++ b/data/110/869/407/5/1108694075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053368,
-    "geom:area_square_m":649203057.842285,
+    "geom:area_square_m":649203057.84162,
     "geom:bbox":"-63.4959506854,10.1532079751,-63.0948386626,10.666222572",
     "geom:latitude":10.334144,
     "geom:longitude":-63.306515,
@@ -79,9 +79,10 @@
         "hasc:id":"VE.BA.AB",
         "wd:id":"Q2849019"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415482,
-    "wof:geomhash":"c428976efc84f088274a0019c09d4666",
+    "wof:geomhash":"38d5d71658159dc837e007f99e33ac1c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108694075,
-    "wof:lastmodified":1566645808,
+    "wof:lastmodified":1695886374,
     "wof:name":"Andres Eloy Blanco",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/407/7/1108694077.geojson
+++ b/data/110/869/407/7/1108694077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034256,
-    "geom:area_square_m":416456254.85336,
+    "geom:area_square_m":416456397.992709,
     "geom:bbox":"-63.439521,10.360509,-63.202049,10.666398",
     "geom:latitude":10.527253,
     "geom:longitude":-63.334143,
@@ -94,9 +94,10 @@
         "hasc:id":"VE.SU.AM",
         "wd:id":"Q2095488"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415484,
-    "wof:geomhash":"e46ca19d09b0bfdcb0091911ab6b39e3",
+    "wof:geomhash":"4a79c8e4425d228e895794b09e4a58ae",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108694077,
-    "wof:lastmodified":1690914999,
+    "wof:lastmodified":1695886373,
     "wof:name":"Andres Mata",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/408/1/1108694081.geojson
+++ b/data/110/869/408/1/1108694081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005008,
-    "geom:area_square_m":60764805.28633,
+    "geom:area_square_m":60764659.94473,
     "geom:bbox":"-63.910046,11.064087,-63.822026,11.18425",
     "geom:latitude":11.113222,
     "geom:longitude":-63.866932,
@@ -233,9 +233,10 @@
         "hasc:id":"VE.NE.AC",
         "wd:id":"Q2856992"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415486,
-    "wof:geomhash":"7ffdf36d836456f21afec02ca1c55a83",
+    "wof:geomhash":"2afdf94c37d63cbed5b3622317c0411f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":1108694081,
-    "wof:lastmodified":1690914996,
+    "wof:lastmodified":1695886372,
     "wof:name":"Antolin Del Campo",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/110/869/408/3/1108694083.geojson
+++ b/data/110/869/408/3/1108694083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.707065,
-    "geom:area_square_m":20879997825.24575,
+    "geom:area_square_m":20879998586.368572,
     "geom:bbox":"-61.790755,7.758151,-59.805666,9.487083",
     "geom:latitude":8.424411,
     "geom:longitude":-60.905313,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.DA.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415488,
-    "wof:geomhash":"34fc6497d4611e8961ebb0f9c4a33453",
+    "wof:geomhash":"105b66f6a6f60d7409c3cbaba263edc8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694083,
-    "wof:lastmodified":1627522969,
+    "wof:lastmodified":1695886179,
     "wof:name":"Antonio Diaz",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/110/869/408/5/1108694085.geojson
+++ b/data/110/869/408/5/1108694085.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415491,
     "wof:geomhash":"2c0a95bc45592c28dfff261f2d54005c",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694085,
-    "wof:lastmodified":1694492827,
+    "wof:lastmodified":1695886251,
     "wof:name":"Antonio Jose De Sucre",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/408/7/1108694087.geojson
+++ b/data/110/869/408/7/1108694087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00973,
-    "geom:area_square_m":119091715.053601,
+    "geom:area_square_m":119091821.231343,
     "geom:bbox":"-72.215559,8.102786,-72.091822,8.249829",
     "geom:latitude":8.179145,
     "geom:longitude":-72.150216,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TA.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415494,
-    "wof:geomhash":"917e34791ebe55b8dce55a3b54a90431",
+    "wof:geomhash":"c819eee3f53c23ad3bac7dcf057185e8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694087,
-    "wof:lastmodified":1627522970,
+    "wof:lastmodified":1695886179,
     "wof:name":"Antonio Romulo Acosta",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/408/9/1108694089.geojson
+++ b/data/110/869/408/9/1108694089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063905,
-    "geom:area_square_m":779021879.00711,
+    "geom:area_square_m":779022276.172434,
     "geom:bbox":"-68.982513,9.427147,-68.722509,9.868384",
     "geom:latitude":9.646524,
     "geom:longitude":-68.858795,
@@ -100,9 +100,10 @@
         "hasc:id":"VE.CO.AN",
         "wd:id":"Q2545745"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415495,
-    "wof:geomhash":"f61e4900d88e2b45f002bc0f27de010c",
+    "wof:geomhash":"97bc34a0af5021537a5a63582fbd3d38",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108694089,
-    "wof:lastmodified":1690914995,
+    "wof:lastmodified":1695886372,
     "wof:name":"Anzoategui",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/409/1/1108694091.geojson
+++ b/data/110/869/409/1/1108694091.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415497,
     "wof:geomhash":"d56078217ea57b41b3ca8c4f923386d2",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694091,
-    "wof:lastmodified":1694492808,
+    "wof:lastmodified":1695886180,
     "wof:name":"Aquiles Nazoa",
     "wof:parent_id":85680535,
     "wof:placetype":"county",

--- a/data/110/869/409/3/1108694093.geojson
+++ b/data/110/869/409/3/1108694093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06671,
-    "geom:area_square_m":813331468.329074,
+    "geom:area_square_m":813331468.329081,
     "geom:bbox":"-69.45,9.40667976288,-69.0590552254,9.84166666667",
     "geom:latitude":9.601718,
     "geom:longitude":-69.289576,
@@ -87,9 +87,10 @@
         "hasc:id":"VE.PO.AR",
         "wd:id":"Q2741347"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415501,
-    "wof:geomhash":"7efad7e52dbd946fce3e764b5a60038e",
+    "wof:geomhash":"3b71f61643a305e73fe0fb3675d1f281",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108694093,
-    "wof:lastmodified":1566645806,
+    "wof:lastmodified":1695886373,
     "wof:name":"Araure",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/409/5/1108694095.geojson
+++ b/data/110/869/409/5/1108694095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077204,
-    "geom:area_square_m":944920770.469585,
+    "geom:area_square_m":944920688.829916,
     "geom:bbox":"-71.29178,7.911591,-70.911913,8.389343",
     "geom:latitude":8.183702,
     "geom:longitude":-71.128567,
@@ -102,9 +102,10 @@
         "hasc:id":"VE.ME.AR",
         "wd:id":"Q2856316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415502,
-    "wof:geomhash":"808d4b44fbed7fed47fa4ee967775e30",
+    "wof:geomhash":"120178b70c78449b203458a9016753d3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108694095,
-    "wof:lastmodified":1690914998,
+    "wof:lastmodified":1695886373,
     "wof:name":"Aricagua",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/409/9/1108694099.geojson
+++ b/data/110/869/409/9/1108694099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.61895,
-    "geom:area_square_m":7574934717.621304,
+    "geom:area_square_m":7574934717.621553,
     "geom:bbox":"-68.8399868534,7.87425497174,-67.5007674849,8.61097098975",
     "geom:latitude":8.211362,
     "geom:longitude":-68.22842,
@@ -84,9 +84,10 @@
         "hasc:id":"VE.BA.AR",
         "wd:id":"Q2183400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415503,
-    "wof:geomhash":"9315e96ac88984cba038578decafcfdd",
+    "wof:geomhash":"a7a6b2c8803169a84d8a12f43718448b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108694099,
-    "wof:lastmodified":1566645806,
+    "wof:lastmodified":1695886373,
     "wof:name":"Arismendi",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/410/1/1108694101.geojson
+++ b/data/110/869/410/1/1108694101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005,
-    "geom:area_square_m":60832786.09398,
+    "geom:area_square_m":60832826.839957,
     "geom:bbox":"-68.909137,10.192664,-68.796309,10.322221",
     "geom:latitude":10.254871,
     "geom:longitude":-68.857705,
@@ -115,9 +115,10 @@
         "hasc:id":"VE.YA.BR",
         "wd:id":"Q2927131"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415506,
-    "wof:geomhash":"e8c70a0e68f41f7b55f6b899044ae584",
+    "wof:geomhash":"573f413a58720f147ed6821d55c2f625",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108694101,
-    "wof:lastmodified":1690915008,
+    "wof:lastmodified":1695886376,
     "wof:name":"Aristides Bastidas",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/410/3/1108694103.geojson
+++ b/data/110/869/410/3/1108694103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064401,
-    "geom:area_square_m":786949175.872645,
+    "geom:area_square_m":786949175.872824,
     "geom:bbox":"-70.2521258541,8.61,-69.7469346825,9.06136831464",
     "geom:latitude":8.804999,
     "geom:longitude":-70.010768,
@@ -100,9 +100,10 @@
         "hasc:id":"VE.BA.AT",
         "wd:id":"Q704971"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415509,
-    "wof:geomhash":"fef00f7960030dc52ecdcad1d2d9ef97",
+    "wof:geomhash":"2424d922f6248c36cbea28597d8973a9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108694103,
-    "wof:lastmodified":1566645813,
+    "wof:lastmodified":1695886376,
     "wof:name":"Arvelo",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/410/5/1108694105.geojson
+++ b/data/110/869/410/5/1108694105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.974439,
-    "geom:area_square_m":12006926173.890892,
+    "geom:area_square_m":12006926173.889797,
     "geom:bbox":"-67.854817,4.10784141875,-66.5207269294,5.59873518983",
     "geom:latitude":4.783611,
     "geom:longitude":-67.266974,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"VE.AM.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415512,
-    "wof:geomhash":"03fd73c1e63d7f9cf1e16aff1b53743d",
+    "wof:geomhash":"fa1936b1d71d26dc42cf0484575d5141",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108694105,
-    "wof:lastmodified":1566645813,
+    "wof:lastmodified":1695886376,
     "wof:name":"Autana",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/110/869/410/7/1108694107.geojson
+++ b/data/110/869/410/7/1108694107.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415514,
     "wof:geomhash":"da2b4e827989d0e2eb2b5a261a6930d2",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694107,
-    "wof:lastmodified":1694492827,
+    "wof:lastmodified":1695886251,
     "wof:name":"Avila",
     "wof:parent_id":85680535,
     "wof:placetype":"county",

--- a/data/110/869/410/9/1108694109.geojson
+++ b/data/110/869/410/9/1108694109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161291,
-    "geom:area_square_m":1964706746.177264,
+    "geom:area_square_m":1964707315.647806,
     "geom:bbox":"-71.089242,9.588805,-70.668584,10.344362",
     "geom:latitude":9.895862,
     "geom:longitude":-70.878453,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.ZU.BA",
         "wd:id":"Q2201316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415516,
-    "wof:geomhash":"c9d4c70a279ca2b0759d6b1dc38767d5",
+    "wof:geomhash":"15550f6b2cdd7c8b7edec86f015129f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694109,
-    "wof:lastmodified":1690915008,
+    "wof:lastmodified":1695886376,
     "wof:name":"Baralt",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/411/1/1108694111.geojson
+++ b/data/110/869/411/1/1108694111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223083,
-    "geom:area_square_m":2713839530.896143,
+    "geom:area_square_m":2713839157.608282,
     "geom:bbox":"-63.29769,10.037587,-62.615417,10.63145",
     "geom:latitude":10.319802,
     "geom:longitude":-62.941123,
@@ -91,9 +91,10 @@
         "hasc:id":"VE.SU.BN",
         "wd:id":"Q1891862"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415521,
-    "wof:geomhash":"3e44e7da649a543b5326777f4250efb8",
+    "wof:geomhash":"18d93a65899556837f01ff500cc24a9e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108694111,
-    "wof:lastmodified":1690915010,
+    "wof:lastmodified":1695886377,
     "wof:name":"Benitez",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/411/3/1108694113.geojson
+++ b/data/110/869/411/3/1108694113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015307,
-    "geom:area_square_m":186017349.652353,
+    "geom:area_square_m":186016962.612428,
     "geom:bbox":"-63.43884,10.537764,-63.170157,10.700443",
     "geom:latitude":10.636588,
     "geom:longitude":-63.26954,
@@ -103,9 +103,10 @@
         "hasc:id":"VE.SU.BR",
         "wd:id":"Q2309997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415522,
-    "wof:geomhash":"a5b0c2ecd48e6d97e606a954641a845f",
+    "wof:geomhash":"2b5603bf5376872ea630940586a75c6c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108694113,
-    "wof:lastmodified":1690915010,
+    "wof:lastmodified":1695886377,
     "wof:name":"Bermudez",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/411/7/1108694117.geojson
+++ b/data/110/869/411/7/1108694117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092697,
-    "geom:area_square_m":1135547106.670556,
+    "geom:area_square_m":1135547106.670458,
     "geom:bbox":"-68.0395397509,7.65175608967,-67.4976772262,7.98760427719",
     "geom:latitude":7.825332,
     "geom:longitude":-67.691643,
@@ -85,9 +85,10 @@
         "hasc:id":"VE.BA.AR",
         "wd:id":"Q2183400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415524,
-    "wof:geomhash":"b38fda1cb436dc24a991270325551066",
+    "wof:geomhash":"c39933d11456eb9bd0aadb531833951c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108694117,
-    "wof:lastmodified":1566645815,
+    "wof:lastmodified":1695886377,
     "wof:name":"Biruaca",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/110/869/411/9/1108694119.geojson
+++ b/data/110/869/411/9/1108694119.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415528,
     "wof:geomhash":"3e4c61718a5bfb27d9cd09bd4f51990b",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108694119,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Bolivar",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/412/1/1108694121.geojson
+++ b/data/110/869/412/1/1108694121.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415530,
     "wof:geomhash":"345013eeb0ad2b0ff83a49d7b0935404",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108694121,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886192,
     "wof:name":"Bolivar",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/412/3/1108694123.geojson
+++ b/data/110/869/412/3/1108694123.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415531,
     "wof:geomhash":"66fec8bab1b333ea09ca2d12ac807a27",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108694123,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886192,
     "wof:name":"Bolivar",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/412/5/1108694125.geojson
+++ b/data/110/869/412/5/1108694125.geojson
@@ -57,6 +57,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415533,
     "wof:geomhash":"9b81135352185aed9566112fb480973c",
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108694125,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886192,
     "wof:name":"Bolivar",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/412/7/1108694127.geojson
+++ b/data/110/869/412/7/1108694127.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.YA.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415536,
     "wof:geomhash":"c75e8046acc982accf7a780a65efc0ea",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694127,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886370,
     "wof:name":"Bruzual",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/412/9/1108694129.geojson
+++ b/data/110/869/412/9/1108694129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031968,
-    "geom:area_square_m":389070969.230888,
+    "geom:area_square_m":389070738.878377,
     "geom:bbox":"-68.988289,10.072849,-68.716688,10.329457",
     "geom:latitude":10.177441,
     "geom:longitude":-68.87253,
@@ -109,9 +109,10 @@
         "hasc:id":"VE.YA.NI",
         "wd:id":"Q10801437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415537,
-    "wof:geomhash":"25bd37c3b125fb036f7a1172edb4261c",
+    "wof:geomhash":"bf47cb56b0c416cf6304166cae106758",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108694129,
-    "wof:lastmodified":1690914988,
+    "wof:lastmodified":1695886370,
     "wof:name":"Bruzual",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/413/1/1108694131.geojson
+++ b/data/110/869/413/1/1108694131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.27498,
-    "geom:area_square_m":3338866198.368707,
+    "geom:area_square_m":3338866103.177485,
     "geom:bbox":"-70.969785,10.3,-70.309814,11.327917",
     "geom:latitude":10.894168,
     "geom:longitude":-70.631084,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"VE.FA.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415539,
-    "wof:geomhash":"b11f43416c5605759b8eee5762f3031f",
+    "wof:geomhash":"c5496ea001f44311f2f2419f750cbe47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694131,
-    "wof:lastmodified":1627522970,
+    "wof:lastmodified":1695886180,
     "wof:name":"Buchivacoa",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/413/5/1108694135.geojson
+++ b/data/110/869/413/5/1108694135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017928,
-    "geom:area_square_m":217622824.679552,
+    "geom:area_square_m":217622726.379772,
     "geom:bbox":"-68.620893,10.917468,-68.45,11.067964",
     "geom:latitude":10.986571,
     "geom:longitude":-68.54769,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"VE.FA.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415543,
-    "wof:geomhash":"e0345f85fdeaadf6ade456b0d058a1e4",
+    "wof:geomhash":"0631615651bffa10d22b3e086d2bab26",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694135,
-    "wof:lastmodified":1627522970,
+    "wof:lastmodified":1695886180,
     "wof:name":"Cacique Manaure",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/413/7/1108694137.geojson
+++ b/data/110/869/413/7/1108694137.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"VE.SU.CJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415545,
     "wof:geomhash":"243619f8c92db8f753216ca078047b10",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108694137,
-    "wof:lastmodified":1694492835,
+    "wof:lastmodified":1695886271,
     "wof:name":"Cajigal",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/413/9/1108694139.geojson
+++ b/data/110/869/413/9/1108694139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027247,
-    "geom:area_square_m":331147607.770197,
+    "geom:area_square_m":331147543.19002,
     "geom:bbox":"-62.944639,10.529996,-62.693868,10.691307",
     "geom:latitude":10.613605,
     "geom:longitude":-62.822944,
@@ -81,9 +81,10 @@
         "hasc:id":"VE.SU.CJ",
         "wd:id":"Q2554123"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415546,
-    "wof:geomhash":"15a1eaca6e74c4cfe490a130a53bbd0b",
+    "wof:geomhash":"ae27cda194cb5829a2c795418626a01a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108694139,
-    "wof:lastmodified":1690914979,
+    "wof:lastmodified":1695886368,
     "wof:name":"Cajigal",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/414/1/1108694141.geojson
+++ b/data/110/869/414/1/1108694141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117477,
-    "geom:area_square_m":1437772309.053636,
+    "geom:area_square_m":1437772369.036402,
     "geom:bbox":"-67.834283,7.891133,-67.364914,8.445416",
     "geom:latitude":8.1996,
     "geom:longitude":-67.555401,
@@ -128,9 +128,10 @@
         "hasc:id":"VE.GU.CA",
         "wd:id":"Q1027967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415549,
-    "wof:geomhash":"b645d8df1c509559c2f483494a7d07ca",
+    "wof:geomhash":"183dcc72249e41158a2be4705d72f35d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108694141,
-    "wof:lastmodified":1690914980,
+    "wof:lastmodified":1695886368,
     "wof:name":"Camaguan",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/414/3/1108694143.geojson
+++ b/data/110/869/414/3/1108694143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038993,
-    "geom:area_square_m":475337025.816035,
+    "geom:area_square_m":475337176.919724,
     "geom:bbox":"-70.56,9.50953,-70.289242,9.805785",
     "geom:latitude":9.646928,
     "geom:longitude":-70.422353,
@@ -78,9 +78,10 @@
         "hasc:id":"VE.TR.CN",
         "wd:id":"Q2936242"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415552,
-    "wof:geomhash":"dffeeb2e57b54f1803f964e386eb2c07",
+    "wof:geomhash":"8ccd1d47e96373aead279488c551a244",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108694143,
-    "wof:lastmodified":1690914981,
+    "wof:lastmodified":1695886368,
     "wof:name":"Candelaria",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/414/5/1108694145.geojson
+++ b/data/110/869/414/5/1108694145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048425,
-    "geom:area_square_m":591679238.03269,
+    "geom:area_square_m":591679057.683289,
     "geom:bbox":"-71.355931,8.712917,-71.027239,8.949671",
     "geom:latitude":8.837002,
     "geom:longitude":-71.197252,
@@ -97,9 +97,10 @@
         "hasc:id":"VE.ME.CO",
         "wd:id":"Q2623246"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415554,
-    "wof:geomhash":"13f6e7fbc130cecbfd936560342428aa",
+    "wof:geomhash":"5228cf67dc7a8401d398aae1b6b651a2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694145,
-    "wof:lastmodified":1690914981,
+    "wof:lastmodified":1695886368,
     "wof:name":"Caracciolo Parra Olmedo",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/414/7/1108694147.geojson
+++ b/data/110/869/414/7/1108694147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087377,
-    "geom:area_square_m":1065101445.14328,
+    "geom:area_square_m":1065101584.033312,
     "geom:bbox":"-70.487564,9.420851,-69.99861,9.834122",
     "geom:latitude":9.66455,
     "geom:longitude":-70.234081,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.TR.CR",
         "wd:id":"Q2565242"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415556,
-    "wof:geomhash":"abede6603b4865e224fd2fc039ac2b91",
+    "wof:geomhash":"88e30ce519f20dee425afce45943fd14",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694147,
-    "wof:lastmodified":1690914980,
+    "wof:lastmodified":1695886368,
     "wof:name":"Carache",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/414/9/1108694149.geojson
+++ b/data/110/869/414/9/1108694149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002405,
-    "geom:area_square_m":29259369.697662,
+    "geom:area_square_m":29259517.442014,
     "geom:bbox":"-67.019341,10.320275,-66.958632,10.389215",
     "geom:latitude":10.353602,
     "geom:longitude":-66.994412,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.MI.GU",
         "wd:id":"Q1090454"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415562,
-    "wof:geomhash":"63b2f6094177a33bf5d1393b43c78a57",
+    "wof:geomhash":"36705e33a5621a39c14da582f82a213f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694149,
-    "wof:lastmodified":1690914980,
+    "wof:lastmodified":1695886368,
     "wof:name":"Carrizal",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/415/3/1108694153.geojson
+++ b/data/110/869/415/3/1108694153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.364323,
-    "geom:area_square_m":4448237005.789614,
+    "geom:area_square_m":4448235611.971035,
     "geom:bbox":"-72.495853,8.365017,-71.720497,9.6102",
     "geom:latitude":9.09428,
     "geom:longitude":-72.171534,
@@ -90,9 +90,10 @@
         "hasc:id":"VE.ZU.CT",
         "wd:id":"Q2370436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415565,
-    "wof:geomhash":"1442d765ec4fea531b1bcc95a0c5b231",
+    "wof:geomhash":"d4a099f7cac39d00e46680b558e6a59d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108694153,
-    "wof:lastmodified":1690914987,
+    "wof:lastmodified":1695886370,
     "wof:name":"Catatumbo",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/415/5/1108694155.geojson
+++ b/data/110/869/415/5/1108694155.geojson
@@ -72,6 +72,7 @@
     "wof:concordances":{
         "hasc:id":"VE.BO.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415568,
     "wof:geomhash":"3cd46ee5522de96ef649514fe41450c5",
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108694155,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886370,
     "wof:name":"Cede\u00f1o",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/415/7/1108694157.geojson
+++ b/data/110/869/415/7/1108694157.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415569,
     "wof:geomhash":"b515c39bb6b3ad6ef5924032dac685b6",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108694157,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886370,
     "wof:name":"Chacao",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/415/9/1108694159.geojson
+++ b/data/110/869/415/9/1108694159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190213,
-    "geom:area_square_m":2320762066.099048,
+    "geom:area_square_m":2320761653.33046,
     "geom:bbox":"-66.716324,9.025551,-65.9975,9.655628",
     "geom:latitude":9.350237,
     "geom:longitude":-66.291934,
@@ -178,9 +178,10 @@
         "hasc:id":"VE.GU.CH",
         "wd:id":"Q1058857"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415571,
-    "wof:geomhash":"c25f14fbcaf0def08c0f1a798265fcba",
+    "wof:geomhash":"15de68236e4c33b901a48871e54f8d47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1108694159,
-    "wof:lastmodified":1690914987,
+    "wof:lastmodified":1695886192,
     "wof:name":"Chaguaramas",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/416/1/1108694161.geojson
+++ b/data/110/869/416/1/1108694161.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415573,
     "wof:geomhash":"7f05e87a61f8b38477aabd58c9d356b9",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694161,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886378,
     "wof:name":"Cocorote",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/416/3/1108694163.geojson
+++ b/data/110/869/416/3/1108694163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063298,
-    "geom:area_square_m":769999641.327892,
+    "geom:area_square_m":770000389.116758,
     "geom:bbox":"-69.310146,10.140725,-69.008263,10.485982",
     "geom:latitude":10.330916,
     "geom:longitude":-69.153992,
@@ -121,9 +121,10 @@
         "hasc:id":"VE.LA.CR",
         "wd:id":"Q1913811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415578,
-    "wof:geomhash":"efb348ffdc496de73af5c18fcf85aebe",
+    "wof:geomhash":"1867123477323946646f882c095b2278",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108694163,
-    "wof:lastmodified":1690915011,
+    "wof:lastmodified":1695886378,
     "wof:name":"Crespo",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/110/869/416/5/1108694165.geojson
+++ b/data/110/869/416/5/1108694165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103236,
-    "geom:area_square_m":1254214259.29287,
+    "geom:area_square_m":1254214195.210892,
     "geom:bbox":"-70.756719,10.324516,-70.511416,11.109509",
     "geom:latitude":10.727877,
     "geom:longitude":-70.624605,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.FA.DA",
         "wd:id":"Q2651190"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415583,
-    "wof:geomhash":"08e00e5836053a0ad7984d1f40262ae4",
+    "wof:geomhash":"1c9f36fb13ad7b4eb9eaa7c63d7c5a91",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694165,
-    "wof:lastmodified":1690915011,
+    "wof:lastmodified":1695886378,
     "wof:name":"Dabajuro",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/416/7/1108694167.geojson
+++ b/data/110/869/416/7/1108694167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22194,
-    "geom:area_square_m":2695403627.78135,
+    "geom:area_square_m":2695404182.563897,
     "geom:bbox":"-70.491188,10.5482,-69.819105,11.219715",
     "geom:latitude":10.834956,
     "geom:longitude":-70.166545,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.FA.DE",
         "wd:id":"Q2328156"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415585,
-    "wof:geomhash":"05f2b0b8457bf6d72b87353a404c3c1c",
+    "wof:geomhash":"3ad6041eec1fbfc907e01f61e19a9fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694167,
-    "wof:lastmodified":1690915010,
+    "wof:lastmodified":1695886378,
     "wof:name":"Democracia",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/417/1/1108694171.geojson
+++ b/data/110/869/417/1/1108694171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009937,
-    "geom:area_square_m":120903721.713196,
+    "geom:area_square_m":120903891.180275,
     "geom:bbox":"-67.741589,10.190362,-67.65097,10.34476",
     "geom:latitude":10.274754,
     "geom:longitude":-67.698393,
@@ -135,9 +135,10 @@
         "hasc:id":"VE.CA.DI",
         "wd:id":"Q1220474"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415587,
-    "wof:geomhash":"532fb757fa90943a7b05263625f3ffd9",
+    "wof:geomhash":"8c0342a99dcf485813f60f9b93b20716",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108694171,
-    "wof:lastmodified":1690915007,
+    "wof:lastmodified":1695886376,
     "wof:name":"Diego Ibarra",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/417/3/1108694173.geojson
+++ b/data/110/869/417/3/1108694173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218841,
-    "geom:area_square_m":2684580315.423628,
+    "geom:area_square_m":2684580777.530287,
     "geom:bbox":"-62.022946,6.748274,-61.610858,7.683678",
     "geom:latitude":7.213373,
     "geom:longitude":-61.77088,
@@ -108,9 +108,10 @@
         "hasc:id":"VE.BO.RO",
         "wd:id":"Q2100029"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415589,
-    "wof:geomhash":"3434ee873942c240c3f1d55abbe04595",
+    "wof:geomhash":"91272700e8a08b3abe73987b3b9b9967",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108694173,
-    "wof:lastmodified":1690915007,
+    "wof:lastmodified":1695886376,
     "wof:name":"El Callao",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/110/869/417/5/1108694175.geojson
+++ b/data/110/869/417/5/1108694175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231831,
-    "geom:area_square_m":2834194673.359746,
+    "geom:area_square_m":2834194643.193542,
     "geom:bbox":"-65.91,7.898094,-65.438551,9.141041",
     "geom:latitude":8.620773,
     "geom:longitude":-65.641455,
@@ -121,9 +121,10 @@
         "hasc:id":"VE.GU.ES",
         "wd:id":"Q1006441"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415592,
-    "wof:geomhash":"a006ec6576a7ae8e6ef73f202ec8471c",
+    "wof:geomhash":"f5a69eeaddca0b64a51fbab99d06c1a0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108694175,
-    "wof:lastmodified":1690915008,
+    "wof:lastmodified":1695886376,
     "wof:name":"El Socorro",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/417/7/1108694177.geojson
+++ b/data/110/869/417/7/1108694177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073028,
-    "geom:area_square_m":891366273.468794,
+    "geom:area_square_m":891366133.645611,
     "geom:bbox":"-69.31084,8.939231,-69.015,9.480773",
     "geom:latitude":9.206244,
     "geom:longitude":-69.189004,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.PO.ES",
         "wd:id":"Q2255063"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415595,
-    "wof:geomhash":"503229bd5b9ec039833d737f5d5aa6de",
+    "wof:geomhash":"a81582ff6defe8cdb9dd4b47e400ffc9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694177,
-    "wof:lastmodified":1690915006,
+    "wof:lastmodified":1695886376,
     "wof:name":"Esteller",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/417/9/1108694179.geojson
+++ b/data/110/869/417/9/1108694179.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415597,
     "wof:geomhash":"3c8c2ee5f65f483cac5504f016f8bcc2",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694179,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886376,
     "wof:name":"Ezequiel Zamora",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/418/1/1108694181.geojson
+++ b/data/110/869/418/1/1108694181.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.BA.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415598,
     "wof:geomhash":"e032b172f5e0a105f92a4a9f5d72ce99",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694181,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886378,
     "wof:name":"Ezequiel Zamora",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/418/3/1108694183.geojson
+++ b/data/110/869/418/3/1108694183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034847,
-    "geom:area_square_m":424825362.153371,
+    "geom:area_square_m":424825321.472523,
     "geom:bbox":"-63.819186,9.500668,-63.518877,9.750825",
     "geom:latitude":9.628718,
     "geom:longitude":-63.670607,
@@ -99,9 +99,10 @@
         "hasc:id":"VE.BA.EZ",
         "wd:id":"Q429692"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415600,
-    "wof:geomhash":"be101beb90ca0f5d34c6a9f5ff6a5442",
+    "wof:geomhash":"f0e5eb246f3c3644ef9391cfd71935b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108694183,
-    "wof:lastmodified":1690915013,
+    "wof:lastmodified":1695886378,
     "wof:name":"Ezequiel Zamora",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/418/5/1108694185.geojson
+++ b/data/110/869/418/5/1108694185.geojson
@@ -306,6 +306,7 @@
     "wof:concordances":{
         "hasc:id":"VE.FA.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415601,
     "wof:geomhash":"473489cc03b00700c723e2419f33828d",
@@ -318,7 +319,7 @@
         }
     ],
     "wof:id":1108694185,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886378,
     "wof:name":"Falcon",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/418/9/1108694189.geojson
+++ b/data/110/869/418/9/1108694189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116635,
-    "geom:area_square_m":1416544688.434304,
+    "geom:area_square_m":1416544144.497573,
     "geom:bbox":"-69.902865,10.69117,-69.263984,10.959826",
     "geom:latitude":10.827377,
     "geom:longitude":-69.581772,
@@ -100,9 +100,10 @@
         "hasc:id":"VE.FA.FE",
         "wd:id":"Q3067852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415604,
-    "wof:geomhash":"4367e0864547a97a4d400ea58c22c1cb",
+    "wof:geomhash":"887ecbef7e6f536ad24a6d91a9654a3d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108694189,
-    "wof:lastmodified":1690915013,
+    "wof:lastmodified":1695886378,
     "wof:name":"Federacion",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/419/1/1108694191.geojson
+++ b/data/110/869/419/1/1108694191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084144,
-    "geom:area_square_m":1031468317.095639,
+    "geom:area_square_m":1031468600.844331,
     "geom:bbox":"-72.197596,7.364501,-71.800355,7.735892",
     "geom:latitude":7.535423,
     "geom:longitude":-71.989964,
@@ -97,9 +97,10 @@
         "hasc:id":"VE.TA.FF",
         "wd:id":"Q974559"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415606,
-    "wof:geomhash":"73a0b09ecb35757d11233cbc9fdfa678",
+    "wof:geomhash":"391cc698c880d37fdfe1f9d9e0662ff4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694191,
-    "wof:lastmodified":1690915002,
+    "wof:lastmodified":1695886374,
     "wof:name":"Fernandez Feo",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/419/3/1108694193.geojson
+++ b/data/110/869/419/3/1108694193.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415608,
     "wof:geomhash":"035c9e6e15d683f90a0bb042e76eee30",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694193,
-    "wof:lastmodified":1694492844,
+    "wof:lastmodified":1695886292,
     "wof:name":"Francisco De Miranda",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/419/5/1108694195.geojson
+++ b/data/110/869/419/5/1108694195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05761,
-    "geom:area_square_m":703758575.301578,
+    "geom:area_square_m":703758418.059903,
     "geom:bbox":"-71.689897,8.710123,-71.379271,9.062494",
     "geom:latitude":8.913392,
     "geom:longitude":-71.559624,
@@ -94,9 +94,10 @@
         "hasc:id":"VE.ZU.FP",
         "wd:id":"Q2262088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415610,
-    "wof:geomhash":"56eedf1c753f7753ec7b0b8b5bf138f4",
+    "wof:geomhash":"363387150c60435957e16e104b62b7b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108694195,
-    "wof:lastmodified":1690915002,
+    "wof:lastmodified":1695886374,
     "wof:name":"Francisco Javier Pulgar",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/419/7/1108694197.geojson
+++ b/data/110/869/419/7/1108694197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070782,
-    "geom:area_square_m":865920523.1154,
+    "geom:area_square_m":865920523.11563,
     "geom:bbox":"-72.4156072656,8.16939948503,-72.1273059419,8.56869421366",
     "geom:latitude":8.364323,
     "geom:longitude":-72.257167,
@@ -89,9 +89,10 @@
         "hasc:id":"VE.TA.GH",
         "wd:id":"Q770422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415614,
-    "wof:geomhash":"2e3bd01d308df3f26986c465b3aa9dea",
+    "wof:geomhash":"5dc44cc098578c48376a93866c5a37af",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694197,
-    "wof:lastmodified":1566645809,
+    "wof:lastmodified":1695886374,
     "wof:name":"Garcia De Hevia",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/419/9/1108694199.geojson
+++ b/data/110/869/419/9/1108694199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265006,
-    "geom:area_square_m":3238024571.583486,
+    "geom:area_square_m":3238024815.181403,
     "geom:bbox":"-68.720955,8.538387,-68.002288,9.21478",
     "geom:latitude":8.82782,
     "geom:longitude":-68.365615,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415617,
-    "wof:geomhash":"2fe950e88a71a3e724c37326b0fb5de4",
+    "wof:geomhash":"28ecf444b567e57dcb70055a020434f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108694199,
-    "wof:lastmodified":1636506207,
+    "wof:lastmodified":1695886193,
     "wof:name":"Girardot",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/420/1/1108694201.geojson
+++ b/data/110/869/420/1/1108694201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017084,
-    "geom:area_square_m":207863706.719131,
+    "geom:area_square_m":207863720.195933,
     "geom:bbox":"-67.931429,10.151102,-67.795636,10.375105",
     "geom:latitude":10.261025,
     "geom:longitude":-67.873769,
@@ -133,9 +133,10 @@
         "hasc:id":"VE.CA.GU",
         "wd:id":"Q1446171"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415620,
-    "wof:geomhash":"922c506e2483a1b3bcfc100828b83db0",
+    "wof:geomhash":"016cf971a385d3ac2ee0d20e6fdffe41",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108694201,
-    "wof:lastmodified":1690915012,
+    "wof:lastmodified":1695886378,
     "wof:name":"Guacara",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/420/3/1108694203.geojson
+++ b/data/110/869/420/3/1108694203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.289728,
-    "geom:area_square_m":3542981179.921225,
+    "geom:area_square_m":3542981358.292096,
     "geom:bbox":"-69.505,8.096068,-68.513322,8.790972",
     "geom:latitude":8.522121,
     "geom:longitude":-68.926702,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.PO.GT",
         "wd:id":"Q2916834"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415623,
-    "wof:geomhash":"ef3ec50eaa5847a5cdcfa9378f062a97",
+    "wof:geomhash":"19a4ee91f24654ee02d70567d81cf15f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694203,
-    "wof:lastmodified":1690915013,
+    "wof:lastmodified":1695886378,
     "wof:name":"Guanarito",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/420/7/1108694207.geojson
+++ b/data/110/869/420/7/1108694207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006482,
-    "geom:area_square_m":78872259.276205,
+    "geom:area_square_m":78872013.559784,
     "geom:bbox":"-64.654765,10.180342,-64.486721,10.307083",
     "geom:latitude":10.2258,
     "geom:longitude":-64.557171,
@@ -130,9 +130,10 @@
         "hasc:id":"VE.AN.GU",
         "wd:id":"Q2381428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415626,
-    "wof:geomhash":"a699da4fedf25860fea61302635cd276",
+    "wof:geomhash":"a8c28ff0a7908625636abd1edb976b55",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108694207,
-    "wof:lastmodified":1690915012,
+    "wof:lastmodified":1695886378,
     "wof:name":"Guanta",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/420/9/1108694209.geojson
+++ b/data/110/869/420/9/1108694209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002772,
-    "geom:area_square_m":33953674.178844,
+    "geom:area_square_m":33953507.643396,
     "geom:bbox":"-72.263937,7.830204,-72.192652,7.882654",
     "geom:latitude":7.856051,
     "geom:longitude":-72.2308,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TA.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415629,
-    "wof:geomhash":"7ccb5021ab1c87c4ea2519c033ca30a2",
+    "wof:geomhash":"81be4de3a82968ebcbb29d524537abe1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694209,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Guasimos",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/421/1/1108694211.geojson
+++ b/data/110/869/421/1/1108694211.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415632,
     "wof:geomhash":"318bb51c6e43ecb9ea4bb45ff040dc07",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108694211,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Independencia",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/421/3/1108694213.geojson
+++ b/data/110/869/421/3/1108694213.geojson
@@ -98,6 +98,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415633,
     "wof:geomhash":"ee831ca7a9cc982c97ade4bda41e7722",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108694213,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Independencia",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/421/5/1108694215.geojson
+++ b/data/110/869/421/5/1108694215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181577,
-    "geom:area_square_m":2203839713.174094,
+    "geom:area_square_m":2203839276.953244,
     "geom:bbox":"-69.22332,10.770094,-68.609841,11.258333",
     "geom:latitude":11.019458,
     "geom:longitude":-68.941529,
@@ -99,9 +99,10 @@
         "hasc:id":"VE.FA.JA",
         "wd:id":"Q2328759"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415638,
-    "wof:geomhash":"223974b1c8c94ce99c0f6abacd406c52",
+    "wof:geomhash":"f31ba585742557b05b4ff87fe1bf13f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108694215,
-    "wof:lastmodified":1690915004,
+    "wof:lastmodified":1695886375,
     "wof:name":"Jacura",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/421/7/1108694217.geojson
+++ b/data/110/869/421/7/1108694217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256194,
-    "geom:area_square_m":3113559212.622917,
+    "geom:area_square_m":3113558599.633449,
     "geom:bbox":"-72.900818,10.355581,-71.77514,10.773316",
     "geom:latitude":10.626447,
     "geom:longitude":-72.303126,
@@ -94,9 +94,10 @@
         "hasc:id":"VE.ZU.JL",
         "wd:id":"Q2148353"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415640,
-    "wof:geomhash":"c2a7169ffbeb41d38f2fff1575d1cf8c",
+    "wof:geomhash":"0a32531665332fb891afcb902b6d2492",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108694217,
-    "wof:lastmodified":1690915004,
+    "wof:lastmodified":1695886374,
     "wof:name":"Jesus Enrique Lossada",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/421/9/1108694219.geojson
+++ b/data/110/869/421/9/1108694219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429163,
-    "geom:area_square_m":5239848684.845344,
+    "geom:area_square_m":5239848354.191131,
     "geom:bbox":"-73.351558,8.457573,-72.306711,9.538995",
     "geom:latitude":9.100102,
     "geom:longitude":-72.697118,
@@ -91,9 +91,10 @@
         "hasc:id":"VE.ZU.JS",
         "wd:id":"Q2370436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415642,
-    "wof:geomhash":"7aa1eaa4156d3a12672a070abfc90285",
+    "wof:geomhash":"e5eb2acbf8d1a8c5a8e077f9a0773016",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108694219,
-    "wof:lastmodified":1690915003,
+    "wof:lastmodified":1695886375,
     "wof:name":"Jesus Maria Semprum",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/422/1/1108694221.geojson
+++ b/data/110/869/422/1/1108694221.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415644,
     "wof:geomhash":"ae5719c0731d3dedd781539a19709942",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694221,
-    "wof:lastmodified":1694492852,
+    "wof:lastmodified":1695886310,
     "wof:name":"Jose Angel Lamas",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/422/5/1108694225.geojson
+++ b/data/110/869/422/5/1108694225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010693,
-    "geom:area_square_m":130180530.94381,
+    "geom:area_square_m":130180466.363444,
     "geom:bbox":"-69.067872,10.00079,-68.914831,10.159041",
     "geom:latitude":10.081754,
     "geom:longitude":-68.99721,
@@ -121,9 +121,10 @@
         "hasc:id":"VE.YA.PE",
         "wd:id":"Q2497712"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415645,
-    "wof:geomhash":"9347c969461f5324e4bba550db17767a",
+    "wof:geomhash":"72d53d3139b5c23e12484d26acdf0811",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108694225,
-    "wof:lastmodified":1690914979,
+    "wof:lastmodified":1695886367,
     "wof:name":"Jose Antonio Paez",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/422/7/1108694227.geojson
+++ b/data/110/869/422/7/1108694227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059035,
-    "geom:area_square_m":719205243.831505,
+    "geom:area_square_m":719205336.05959,
     "geom:bbox":"-70.6932,9.69959,-70.32,10.038075",
     "geom:latitude":9.85606,
     "geom:longitude":-70.55728,
@@ -74,9 +74,10 @@
         "hasc:id":"VE.TR.CN",
         "wd:id":"Q2936242"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415647,
-    "wof:geomhash":"a4bc8bb97e3c261bed4616961f0a7018",
+    "wof:geomhash":"3f6e92f1283a4396fc5854e47758079f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108694227,
-    "wof:lastmodified":1690914978,
+    "wof:lastmodified":1695886367,
     "wof:name":"Jose Felipe Marquez Ca\u00f1izalez",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/422/9/1108694229.geojson
+++ b/data/110/869/422/9/1108694229.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415652,
     "wof:geomhash":"2fb9fea9453c85bf4ea5510fac6b33a8",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694229,
-    "wof:lastmodified":1694492852,
+    "wof:lastmodified":1695886310,
     "wof:name":"Juan Vicente Campo Elias",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/423/1/1108694231.geojson
+++ b/data/110/869/423/1/1108694231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005413,
-    "geom:area_square_m":66082141.335642,
+    "geom:area_square_m":66082085.474409,
     "geom:bbox":"-70.952134,9.059849,-70.802733,9.185611",
     "geom:latitude":9.126158,
     "geom:longitude":-70.882096,
@@ -78,9 +78,10 @@
         "hasc:id":"VE.TR.MC",
         "wd:id":"Q1943693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415654,
-    "wof:geomhash":"d1d4593003ca044219ddccca6d264895",
+    "wof:geomhash":"8397fbcd17b296008a31b936f057ba7f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108694231,
-    "wof:lastmodified":1690914989,
+    "wof:lastmodified":1695886371,
     "wof:name":"Julio Cesar Salas",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/423/3/1108694233.geojson
+++ b/data/110/869/423/3/1108694233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146139,
-    "geom:area_square_m":1777533089.960094,
+    "geom:area_square_m":1777533377.20374,
     "geom:bbox":"-72.298728,10.084965,-71.627113,10.513841",
     "geom:latitude":10.368281,
     "geom:longitude":-71.958102,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.ZU.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415657,
-    "wof:geomhash":"39dead8d271c1067b3975ad1f131eaf7",
+    "wof:geomhash":"5f69a4795487043a4480866551875ecf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694233,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"La Ca\u00f1ada De Urdaneta",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/423/5/1108694235.geojson
+++ b/data/110/869/423/5/1108694235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042196,
-    "geom:area_square_m":514631297.177103,
+    "geom:area_square_m":514631297.17704,
     "geom:bbox":"-71.090057373,9.33428614045,-70.8996895245,9.61544722543",
     "geom:latitude":9.479442,
     "geom:longitude":-70.987355,
@@ -159,9 +159,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TR.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415659,
-    "wof:geomhash":"7bbd8415460468b326e3e33506413425",
+    "wof:geomhash":"4241a1f9319ef66bb21740ff7cf6cb2c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108694235,
-    "wof:lastmodified":1566645799,
+    "wof:lastmodified":1695886371,
     "wof:name":"La Ceiba",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/423/7/1108694237.geojson
+++ b/data/110/869/423/7/1108694237.geojson
@@ -75,6 +75,7 @@
     "wof:concordances":{
         "hasc:id":"VE.YA.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415660,
     "wof:geomhash":"1856856a2ad48bc90c75ae8741b31d4b",
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108694237,
-    "wof:lastmodified":1694492808,
+    "wof:lastmodified":1695886181,
     "wof:name":"La Trinidad",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/423/9/1108694239.geojson
+++ b/data/110/869/423/9/1108694239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07631,
-    "geom:area_square_m":928553957.544531,
+    "geom:area_square_m":928553406.111431,
     "geom:bbox":"-71.357971,10.018971,-70.82,10.463889",
     "geom:latitude":10.240841,
     "geom:longitude":-71.130851,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.ZU.LA",
         "wd:id":"Q2847018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415662,
-    "wof:geomhash":"7cd949233e9a1b2239970d583fa0d074",
+    "wof:geomhash":"3f6c372368ad66c17fdea487de9f8bac",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694239,
-    "wof:lastmodified":1690914989,
+    "wof:lastmodified":1695886371,
     "wof:name":"Lagunillas",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/424/3/1108694243.geojson
+++ b/data/110/869/424/3/1108694243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042983,
-    "geom:area_square_m":523318932.046142,
+    "geom:area_square_m":523319068.225387,
     "geom:bbox":"-66.86,9.970658,-66.486501,10.193994",
     "geom:latitude":10.059573,
     "geom:longitude":-66.696035,
@@ -118,9 +118,10 @@
         "hasc:id":"VE.MI.LA",
         "wd:id":"Q1811782"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415663,
-    "wof:geomhash":"8d1e9c48b6b56f81fe484b10c485bb47",
+    "wof:geomhash":"d0aac8c2b785fa8761135b914f01a780",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108694243,
-    "wof:lastmodified":1690914988,
+    "wof:lastmodified":1695886192,
     "wof:name":"Lander",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/424/5/1108694245.geojson
+++ b/data/110/869/424/5/1108694245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.658656,
-    "geom:area_square_m":8056790574.87534,
+    "geom:area_square_m":8056790551.120735,
     "geom:bbox":"-66.8025,7.627586,-66.01,9.222981",
     "geom:latitude":8.401614,
     "geom:longitude":-66.474048,
@@ -133,9 +133,10 @@
         "hasc:id":"VE.GU.LM",
         "wd:id":"Q1450597"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415665,
-    "wof:geomhash":"83fd96cf0b93803d2d5eb5825e7dc2dc",
+    "wof:geomhash":"4b75a444b25a59807cf81895c60c563d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108694245,
-    "wof:lastmodified":1690914988,
+    "wof:lastmodified":1695886370,
     "wof:name":"Las Mercedes",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/424/7/1108694247.geojson
+++ b/data/110/869/424/7/1108694247.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415667,
     "wof:geomhash":"288e2532d616acb2f9501463db7affd8",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694247,
-    "wof:lastmodified":1694492860,
+    "wof:lastmodified":1695886332,
     "wof:name":"Libbertador",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/424/9/1108694249.geojson
+++ b/data/110/869/424/9/1108694249.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415669,
     "wof:geomhash":"26ce12557506051f916039def1795030",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694249,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886371,
     "wof:name":"Libertador",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/425/1/1108694251.geojson
+++ b/data/110/869/425/1/1108694251.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415670,
     "wof:geomhash":"13728fc675a90fd2fe5981335e8c576f",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694251,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886368,
     "wof:name":"Libertador",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/425/3/1108694253.geojson
+++ b/data/110/869/425/3/1108694253.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415672,
     "wof:geomhash":"192a5a1aedf433cd31e666c60135c1ed",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694253,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886368,
     "wof:name":"Libertador",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/425/5/1108694255.geojson
+++ b/data/110/869/425/5/1108694255.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415674,
     "wof:geomhash":"71f27cbb8da37b37153e00b4867a2094",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694255,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886368,
     "wof:name":"Libertador",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/425/7/1108694257.geojson
+++ b/data/110/869/425/7/1108694257.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415675,
     "wof:geomhash":"007c26d7cfae558ba273f58f07eb7c76",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694257,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886368,
     "wof:name":"Libertador",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/426/1/1108694261.geojson
+++ b/data/110/869/426/1/1108694261.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415677,
     "wof:geomhash":"b03aab7b931654a428d9c9040ed63afd",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694261,
-    "wof:lastmodified":1694492860,
+    "wof:lastmodified":1695886332,
     "wof:name":"Libertadtachira",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/426/3/1108694263.geojson
+++ b/data/110/869/426/3/1108694263.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415679,
     "wof:geomhash":"4f96448222bc420bc9ce76f34a424d3a",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694263,
-    "wof:lastmodified":1694492861,
+    "wof:lastmodified":1695886333,
     "wof:name":"Lic. Diego Bautista Urbaneja",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/426/5/1108694265.geojson
+++ b/data/110/869/426/5/1108694265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012612,
-    "geom:area_square_m":153659853.137269,
+    "geom:area_square_m":153659865.421451,
     "geom:bbox":"-68.501398,9.760539,-68.300818,9.89893",
     "geom:latitude":9.82218,
     "geom:longitude":-68.418366,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.CO.LB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415680,
-    "wof:geomhash":"fb54cade932ce4c43102089e20e27f62",
+    "wof:geomhash":"f653396242985471e84f991ec27d6826",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694265,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Lima Blanco",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/426/7/1108694267.geojson
+++ b/data/110/869/426/7/1108694267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006503,
-    "geom:area_square_m":79150949.685849,
+    "geom:area_square_m":79150949.685848,
     "geom:bbox":"-67.9491575295,10.0940093337,-67.8250169412,10.2118090996",
     "geom:latitude":10.14749,
     "geom:longitude":-67.893253,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415682,
-    "wof:geomhash":"2dbdd0d00e30aa0ee68d376ba5a2eb65",
+    "wof:geomhash":"49b0ade44366aec66084489dc97a8963",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108694267,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1695886375,
     "wof:name":"Los Guayos",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/426/9/1108694269.geojson
+++ b/data/110/869/426/9/1108694269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.688025,
-    "geom:area_square_m":8383698011.385802,
+    "geom:area_square_m":8383698011.386722,
     "geom:bbox":"-73.1458816464,9.29225423243,-71.93347168,10.3599591521",
     "geom:latitude":9.786133,
     "geom:longitude":-72.602508,
@@ -86,9 +86,10 @@
         "hasc:id":"VE.ZU.MP",
         "wd:id":"Q2218644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415686,
-    "wof:geomhash":"bc974d5c7dd74710beb9126ac226675c",
+    "wof:geomhash":"c7cb1eb2643cf292ca76f72e22dbc408",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694269,
-    "wof:lastmodified":1566645810,
+    "wof:lastmodified":1695886375,
     "wof:name":"Machiques De Perija",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/427/1/1108694271.geojson
+++ b/data/110/869/427/1/1108694271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.872164,
-    "geom:area_square_m":35382125976.812393,
+    "geom:area_square_m":35382125976.811714,
     "geom:bbox":"-67.1852707733,3.92024345078,-64.5509634395,6.15977567103",
     "geom:latitude":4.930106,
     "geom:longitude":-65.810116,
@@ -112,9 +112,10 @@
         "hasc:id":"VE.AM.MP",
         "wd:id":"Q2309810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415687,
-    "wof:geomhash":"d9ab11cbec10e7be3adfaa95b3b41dcd",
+    "wof:geomhash":"cfb795b5ab1879f45ccac08472c9b05e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108694271,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1695886378,
     "wof:name":"Manapiare",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/110/869/427/3/1108694273.geojson
+++ b/data/110/869/427/3/1108694273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033575,
-    "geom:area_square_m":408025091.111348,
+    "geom:area_square_m":408024883.621516,
     "geom:bbox":"-68.876991,10.46,-68.615394,10.768718",
     "geom:latitude":10.640511,
     "geom:longitude":-68.735008,
@@ -128,9 +128,10 @@
         "hasc:id":"VE.YA.MM",
         "wd:id":"Q2215868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415690,
-    "wof:geomhash":"a75efa88ca32beea6f071b8028dbb109",
+    "wof:geomhash":"9ce9e9c1a7ec27930a87fc9433c81fec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108694273,
-    "wof:lastmodified":1690915015,
+    "wof:lastmodified":1695886379,
     "wof:name":"Manuel Monge",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/427/5/1108694275.geojson
+++ b/data/110/869/427/5/1108694275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034068,
-    "geom:area_square_m":414039286.660334,
+    "geom:area_square_m":414039007.110374,
     "geom:bbox":"-62.748946,10.535389,-62.427791,10.712209",
     "geom:latitude":10.624549,
     "geom:longitude":-62.567849,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.NE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415696,
-    "wof:geomhash":"e14bab103b2fc1115047b6df72aedd7e",
+    "wof:geomhash":"d0409c6272d690c88e8e49b6a1dc5d8a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694275,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Mari\u00f1o",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/427/9/1108694279.geojson
+++ b/data/110/869/427/9/1108694279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.256093,
-    "geom:area_square_m":15514969364.612488,
+    "geom:area_square_m":15514969364.613134,
     "geom:bbox":"-67.860555,1.88250755884,-65.8803100307,3.247778",
     "geom:latitude":2.651974,
     "geom:longitude":-66.882745,
@@ -107,9 +107,10 @@
         "hasc:id":"VE.AM.MR",
         "wd:id":"Q2673918"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415697,
-    "wof:geomhash":"7faa48543401d0d27b688fef4edd0fc2",
+    "wof:geomhash":"802ada9ef602729da6b4c740557d2fb9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108694279,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1695886379,
     "wof:name":"Maroa",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/110/869/428/1/1108694281.geojson
+++ b/data/110/869/428/1/1108694281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173278,
-    "geom:area_square_m":2104680470.866271,
+    "geom:area_square_m":2104680562.300827,
     "geom:bbox":"-71.315019,10.453555,-70.796417,11.126937",
     "geom:latitude":10.796995,
     "geom:longitude":-70.988906,
@@ -102,9 +102,10 @@
         "hasc:id":"VE.FA.MU",
         "wd:id":"Q1886710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415700,
-    "wof:geomhash":"d1a6d4423291fb51526191271126b1a7",
+    "wof:geomhash":"7e6edca209a55f849ff7f8aa412609f5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108694281,
-    "wof:lastmodified":1690915005,
+    "wof:lastmodified":1695886375,
     "wof:name":"Mauroa",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/428/3/1108694283.geojson
+++ b/data/110/869/428/3/1108694283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110208,
-    "geom:area_square_m":1345200153.97216,
+    "geom:area_square_m":1345200593.666025,
     "geom:bbox":"-65.29372,8.924366,-64.747244,9.4425",
     "geom:latitude":9.203417,
     "geom:longitude":-65.019423,
@@ -121,9 +121,10 @@
         "hasc:id":"VE.AN.AR",
         "wd:id":"Q606975"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415703,
-    "wof:geomhash":"67b2605ea41798412726c1cfa275cedd",
+    "wof:geomhash":"540dbf67551f52d7bbc16dd58939e5a5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108694283,
-    "wof:lastmodified":1690915005,
+    "wof:lastmodified":1695886376,
     "wof:name":"Mc. Gregor",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/428/5/1108694285.geojson
+++ b/data/110/869/428/5/1108694285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022477,
-    "geom:area_square_m":273370783.658489,
+    "geom:area_square_m":273370365.031261,
     "geom:bbox":"-63.87,10.300351,-63.668433,10.474972",
     "geom:latitude":10.390962,
     "geom:longitude":-63.766927,
@@ -91,9 +91,10 @@
         "hasc:id":"VE.SU.ME",
         "wd:id":"Q1958023"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415704,
-    "wof:geomhash":"cd15f6250c3ec1c89e8abb64c37b4d52",
+    "wof:geomhash":"a4a9e31309b6d90541e53f5f6f13ae42",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108694285,
-    "wof:lastmodified":1690915006,
+    "wof:lastmodified":1695886376,
     "wof:name":"Mejia",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/428/7/1108694287.geojson
+++ b/data/110/869/428/7/1108694287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010739,
-    "geom:area_square_m":131502616.031394,
+    "geom:area_square_m":131502616.031415,
     "geom:bbox":"-72.2716666667,7.9359695306,-72.124701555,8.08564819961",
     "geom:latitude":7.991657,
     "geom:longitude":-72.183399,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415707,
-    "wof:geomhash":"31d931c3d4cdf8b603843d564e2300d0",
+    "wof:geomhash":"dc8fdaf40a59c16190debcc0cea153bc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108694287,
-    "wof:lastmodified":1566645811,
+    "wof:lastmodified":1695886375,
     "wof:name":"Michelena",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/428/9/1108694289.geojson
+++ b/data/110/869/428/9/1108694289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014893,
-    "geom:area_square_m":181297998.173279,
+    "geom:area_square_m":181297991.738548,
     "geom:bbox":"-68.42201,9.991304,-68.302304,10.226582",
     "geom:latitude":10.112104,
     "geom:longitude":-68.364452,
@@ -116,9 +116,10 @@
         "hasc:id":"VE.YA.NI",
         "wd:id":"Q10801437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415709,
-    "wof:geomhash":"42d1610cd12ba9117c04a57ef806650d",
+    "wof:geomhash":"5deb0c84408a5074bbeac3c3e61c10f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108694289,
-    "wof:lastmodified":1690915004,
+    "wof:lastmodified":1695886194,
     "wof:name":"Miranda",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/429/1/1108694291.geojson
+++ b/data/110/869/429/1/1108694291.geojson
@@ -206,6 +206,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415710,
     "wof:geomhash":"23baac8e09332a12eba35ad9723f0f6f",
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1108694291,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Miranda",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/429/3/1108694293.geojson
+++ b/data/110/869/429/3/1108694293.geojson
@@ -206,6 +206,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415717,
     "wof:geomhash":"7aae8e5e4ea67f922f78a30593343d54",
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1108694293,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Miranda",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/429/7/1108694297.geojson
+++ b/data/110/869/429/7/1108694297.geojson
@@ -206,6 +206,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415718,
     "wof:geomhash":"2f364c204e9f9538e393fab9f9e8c9de",
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1108694297,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Miranda",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/429/9/1108694299.geojson
+++ b/data/110/869/429/9/1108694299.geojson
@@ -206,6 +206,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415719,
     "wof:geomhash":"1d6998115a81311872757e1bad83a448",
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":1108694299,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886194,
     "wof:name":"Miranda",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/430/1/1108694301.geojson
+++ b/data/110/869/430/1/1108694301.geojson
@@ -201,7 +201,7 @@
         }
     ],
     "wof:id":1108694301,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886192,
     "wof:name":"Monagas",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/430/3/1108694303.geojson
+++ b/data/110/869/430/3/1108694303.geojson
@@ -201,7 +201,7 @@
         }
     ],
     "wof:id":1108694303,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886192,
     "wof:name":"Monagas",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/430/5/1108694305.geojson
+++ b/data/110/869/430/5/1108694305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021133,
-    "geom:area_square_m":257749629.251229,
+    "geom:area_square_m":257749629.251185,
     "geom:bbox":"-70.014625721,9.36804270498,-69.827997656,9.56854998408",
     "geom:latitude":9.481211,
     "geom:longitude":-69.926657,
@@ -89,9 +89,10 @@
         "hasc:id":"VE.PO.MU",
         "wd:id":"Q2479642"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415727,
-    "wof:geomhash":"bb0b918ec6074fae33cd9c24aa5f77bc",
+    "wof:geomhash":"6a5916800eb32437a5ca108bb023984d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694305,
-    "wof:lastmodified":1566645802,
+    "wof:lastmodified":1695886372,
     "wof:name":"Monse\u00f1or Jose Vicente De Unda",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/430/7/1108694307.geojson
+++ b/data/110/869/430/7/1108694307.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415729,
     "wof:geomhash":"06f88240a62156039e0f30b82bb24fe6",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694307,
-    "wof:lastmodified":1694492867,
+    "wof:lastmodified":1695886352,
     "wof:name":"Montalban",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/110/869/430/9/1108694309.geojson
+++ b/data/110/869/430/9/1108694309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03002,
-    "geom:area_square_m":366406868.577973,
+    "geom:area_square_m":366406980.19111,
     "geom:bbox":"-71.048913,9.077887,-70.722186,9.376905",
     "geom:latitude":9.221715,
     "geom:longitude":-70.853849,
@@ -78,9 +78,10 @@
         "hasc:id":"VE.TR.MC",
         "wd:id":"Q1943693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415730,
-    "wof:geomhash":"35792b307b7d6607fd72675415096656",
+    "wof:geomhash":"0f617dac181cd34693a24dd5e3707242",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108694309,
-    "wof:lastmodified":1690914993,
+    "wof:lastmodified":1695886371,
     "wof:name":"Monte Carmelo",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/431/1/1108694311.geojson
+++ b/data/110/869/431/1/1108694311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081083,
-    "geom:area_square_m":986682978.340231,
+    "geom:area_square_m":986682777.744012,
     "geom:bbox":"-64.110106,10.088541,-63.702093,10.376573",
     "geom:latitude":10.224622,
     "geom:longitude":-63.9225,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.SU.MO",
         "wd:id":"Q1823071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415732,
-    "wof:geomhash":"51fbcf6ad1a0d6adac6e42469bf9d151",
+    "wof:geomhash":"aa83e4e808d6e70ae17d2a93099ec36d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694311,
-    "wof:lastmodified":1690914999,
+    "wof:lastmodified":1695886373,
     "wof:name":"Montes",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/431/5/1108694315.geojson
+++ b/data/110/869/431/5/1108694315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010774,
-    "geom:area_square_m":131418868.400162,
+    "geom:area_square_m":131418798.711413,
     "geom:bbox":"-70.662016,9.35,-70.560714,9.558348",
     "geom:latitude":9.447315,
     "geom:longitude":-70.609806,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TR.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415734,
-    "wof:geomhash":"64a40195aeb143e442c8ec8888cd5c54",
+    "wof:geomhash":"cefd3e496975fcf0f0b38fb549f74d02",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694315,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Motatan",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/431/7/1108694317.geojson
+++ b/data/110/869/431/7/1108694317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150694,
-    "geom:area_square_m":1843230027.9806,
+    "geom:area_square_m":1843229813.660775,
     "geom:bbox":"-70.291605,8.05,-69.44,8.75953",
     "geom:latitude":8.427283,
     "geom:longitude":-69.881008,
@@ -99,9 +99,10 @@
         "hasc:id":"VE.BA.OB",
         "wd:id":"Q2606907"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415739,
-    "wof:geomhash":"4c62e4782d61ac71bfa9dec2e4e8f47e",
+    "wof:geomhash":"d4f33ae23676b9bec8f18393a3d51af7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108694317,
-    "wof:lastmodified":1690914999,
+    "wof:lastmodified":1695886373,
     "wof:name":"Obispos",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/431/9/1108694319.geojson
+++ b/data/110/869/431/9/1108694319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.339042,
-    "geom:area_square_m":4134804971.463703,
+    "geom:area_square_m":4134805369.746744,
     "geom:bbox":"-67.964113,9.197684,-67.2,9.933652",
     "geom:latitude":9.500426,
     "geom:longitude":-67.601564,
@@ -136,9 +136,10 @@
         "hasc:id":"VE.GU.OR",
         "wd:id":"Q1308380"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415741,
-    "wof:geomhash":"dfc28b4c3cd2e06237dfea7962020931",
+    "wof:geomhash":"c59be1b09009738eb75463e6c1ba6d68",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108694319,
-    "wof:lastmodified":1690914998,
+    "wof:lastmodified":1695886374,
     "wof:name":"Ortiz",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/432/1/1108694321.geojson
+++ b/data/110/869/432/1/1108694321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162069,
-    "geom:area_square_m":1977696706.286031,
+    "geom:area_square_m":1977697368.201312,
     "geom:bbox":"-69.68927,8.934016,-69.105487,9.6375",
     "geom:latitude":9.294446,
     "geom:longitude":-69.43062,
@@ -102,9 +102,10 @@
         "hasc:id":"VE.PO.OS",
         "wd:id":"Q3087224"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415742,
-    "wof:geomhash":"825c57569aa0615f38d579a66256fd20",
+    "wof:geomhash":"6964c3ddefd7008bd0f3322e6cf3df4d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108694321,
-    "wof:lastmodified":1690915021,
+    "wof:lastmodified":1695886380,
     "wof:name":"Ospino",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/432/3/1108694323.geojson
+++ b/data/110/869/432/3/1108694323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017964,
-    "geom:area_square_m":220072200.368117,
+    "geom:area_square_m":220071826.573309,
     "geom:bbox":"-71.528911,7.671281,-71.369154,7.909412",
     "geom:latitude":7.804746,
     "geom:longitude":-71.463946,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.ME.PN",
         "wd:id":"Q2674477"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415744,
-    "wof:geomhash":"f468ef865f4d3483fb11993125586423",
+    "wof:geomhash":"0572947bdb5ad6ad4f74ebe91ace8e1b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694323,
-    "wof:lastmodified":1690915022,
+    "wof:lastmodified":1695886380,
     "wof:name":"Padre Noguera",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/432/5/1108694325.geojson
+++ b/data/110/869/432/5/1108694325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293777,
-    "geom:area_square_m":3596645923.212501,
+    "geom:area_square_m":3596645698.541761,
     "geom:bbox":"-62.269136,7.576678,-61.648293,8.441225",
     "geom:latitude":8.066637,
     "geom:longitude":-61.945304,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.BO.PC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415746,
-    "wof:geomhash":"9d02fd78ea28351912d9b7e9818e8282",
+    "wof:geomhash":"80115cb09a6b624a620d93f61ad4c128",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694325,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Padre Pedro Chien",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/110/869/432/7/1108694327.geojson
+++ b/data/110/869/432/7/1108694327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02142,
-    "geom:area_square_m":260848775.342338,
+    "geom:area_square_m":260848662.273129,
     "geom:bbox":"-69.319156,9.899284,-69.149698,10.075623",
     "geom:latitude":9.987987,
     "geom:longitude":-69.233471,
@@ -114,9 +114,10 @@
         "hasc:id":"VE.LA.PA",
         "wd:id":"Q2307377"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415751,
-    "wof:geomhash":"f2b759afad9321ea594cf01ae5e8d0e9",
+    "wof:geomhash":"a7dde2e13f1325c64150d19e78d84fe6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108694327,
-    "wof:lastmodified":1690915021,
+    "wof:lastmodified":1695886380,
     "wof:name":"Palavecino",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/110/869/432/9/1108694329.geojson
+++ b/data/110/869/432/9/1108694329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022062,
-    "geom:area_square_m":268071949.856829,
+    "geom:area_square_m":268071879.476743,
     "geom:bbox":"-68.647993,10.60043,-68.459737,10.776364",
     "geom:latitude":10.6796,
     "geom:longitude":-68.56187,
@@ -103,9 +103,10 @@
         "hasc:id":"VE.FA.PA",
         "wd:id":"Q507132"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415753,
-    "wof:geomhash":"2fc89402c30c80a99fc2c2eb58c546e1",
+    "wof:geomhash":"f6b1ad5c0780992c1734e4ab4d54cdf3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108694329,
-    "wof:lastmodified":1690915021,
+    "wof:lastmodified":1695886380,
     "wof:name":"Palmasola",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/433/3/1108694333.geojson
+++ b/data/110/869/433/3/1108694333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033697,
-    "geom:area_square_m":410935063.091587,
+    "geom:area_square_m":410934998.161526,
     "geom:bbox":"-70.616364,9.423383,-70.288861,9.622534",
     "geom:latitude":9.517925,
     "geom:longitude":-70.458846,
@@ -94,9 +94,10 @@
         "hasc:id":"VE.TR.PA",
         "wd:id":"Q9035906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415756,
-    "wof:geomhash":"7a74f8077eec93978ef3b9ed982cad91",
+    "wof:geomhash":"df71171c0deb80852c450cdf57802f6a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108694333,
-    "wof:lastmodified":1690915020,
+    "wof:lastmodified":1695886380,
     "wof:name":"Pampan",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/433/5/1108694335.geojson
+++ b/data/110/869/433/5/1108694335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060408,
-    "geom:area_square_m":738788287.044685,
+    "geom:area_square_m":738788023.538203,
     "geom:bbox":"-72.198368,8.298718,-71.939442,8.659895",
     "geom:latitude":8.479891,
     "geom:longitude":-72.066685,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.TA.PA",
         "wd:id":"Q2162569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415758,
-    "wof:geomhash":"cdc5a685ef55d0a7b552aad518eee2d4",
+    "wof:geomhash":"e48bb1912e4229ee87f032fc0d528964",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694335,
-    "wof:lastmodified":1690915020,
+    "wof:lastmodified":1695886380,
     "wof:name":"Panamericano",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/433/7/1108694337.geojson
+++ b/data/110/869/433/7/1108694337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.385765,
-    "geom:area_square_m":4706331629.338619,
+    "geom:area_square_m":4706331629.339299,
     "geom:bbox":"-68.3702464515,8.635,-67.7503007988,9.86639311074",
     "geom:latitude":9.37236,
     "geom:longitude":-68.076523,
@@ -89,9 +89,10 @@
         "hasc:id":"VE.CO.EP",
         "wd:id":"Q1869244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415759,
-    "wof:geomhash":"963af1987f3bfa284202e5983c8569b2",
+    "wof:geomhash":"3ca0e5380dba7ecc4ca4ed944bf4a27b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694337,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1695886380,
     "wof:name":"Pao De San Juan Bautista",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/433/9/1108694339.geojson
+++ b/data/110/869/433/9/1108694339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207807,
-    "geom:area_square_m":2539038969.659001,
+    "geom:area_square_m":2539038158.669022,
     "geom:bbox":"-69.697012,8.673797,-68.604161,9.050616",
     "geom:latitude":8.840989,
     "geom:longitude":-69.242476,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.PO.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415761,
-    "wof:geomhash":"ff8a55bc5d7e93e1ad517ead106da301",
+    "wof:geomhash":"638411a723fe221b43ac6eea8cf1f03c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694339,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886182,
     "wof:name":"Papelon",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/434/1/1108694341.geojson
+++ b/data/110/869/434/1/1108694341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035159,
-    "geom:area_square_m":427705110.251678,
+    "geom:area_square_m":427704696.541293,
     "geom:bbox":"-66.823823,10.226236,-66.510135,10.4125",
     "geom:latitude":10.326449,
     "geom:longitude":-66.644027,
@@ -111,9 +111,10 @@
         "hasc:id":"VE.MI.PC",
         "wd:id":"Q1149232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415762,
-    "wof:geomhash":"b9abf23fa255670a5dd771a15bcf6844",
+    "wof:geomhash":"a25559a10075ce95865fe3421b1287c1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108694341,
-    "wof:lastmodified":1690915018,
+    "wof:lastmodified":1695886379,
     "wof:name":"Paz Castillo",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/434/3/1108694343.geojson
+++ b/data/110/869/434/3/1108694343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.563371,
-    "geom:area_square_m":6898610232.788395,
+    "geom:area_square_m":6898610011.636351,
     "geom:bbox":"-70.818984,7.392051,-69.585356,8.768174",
     "geom:latitude":7.980862,
     "geom:longitude":-70.349121,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.BA.PE",
         "wd:id":"Q2135709"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415764,
-    "wof:geomhash":"9e1afb19a0317ea2bcb165df16474c32",
+    "wof:geomhash":"c0ad58ed1e8de25b75c3839da0e17209",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694343,
-    "wof:lastmodified":1690915019,
+    "wof:lastmodified":1695886379,
     "wof:name":"Pedraza",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/434/5/1108694345.geojson
+++ b/data/110/869/434/5/1108694345.geojson
@@ -60,6 +60,7 @@
     "wof:concordances":{
         "hasc:id":"VE.DP.DP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415767,
     "wof:geomhash":"b77c980ef1d5ef133b074e33bc3c538e",
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1108694345,
-    "wof:lastmodified":1694492874,
+    "wof:lastmodified":1695886375,
     "wof:name":"Pedro Gual",
     "wof:parent_id":85680539,
     "wof:placetype":"county",

--- a/data/110/869/434/7/1108694347.geojson
+++ b/data/110/869/434/7/1108694347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013646,
-    "geom:area_square_m":167120532.212898,
+    "geom:area_square_m":167120463.659263,
     "geom:bbox":"-72.48739,7.866643,-72.347419,8.035171",
     "geom:latitude":7.946961,
     "geom:longitude":-72.411761,
@@ -97,9 +97,10 @@
         "hasc:id":"VE.TA.PU",
         "wd:id":"Q2627020"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415769,
-    "wof:geomhash":"6bd1ef70684e5c1a9e4cfe7de8eb9078",
+    "wof:geomhash":"6f38fb75823d50cf1058d01f03744407",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694347,
-    "wof:lastmodified":1690915018,
+    "wof:lastmodified":1695886379,
     "wof:name":"Pedro Maria Ure\u00f1a",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/435/1/1108694351.geojson
+++ b/data/110/869/435/1/1108694351.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.BO.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415775,
     "wof:geomhash":"fb67ca38f3debdb5f3ec02b9212ef59b",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694351,
-    "wof:lastmodified":1694492874,
+    "wof:lastmodified":1695886375,
     "wof:name":"Piar",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/435/3/1108694353.geojson
+++ b/data/110/869/435/3/1108694353.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415777,
     "wof:geomhash":"0e7ded7c5632c2b8e828674efb09bdea",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694353,
-    "wof:lastmodified":1694492876,
+    "wof:lastmodified":1695886381,
     "wof:name":"Piritu",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/435/5/1108694355.geojson
+++ b/data/110/869/435/5/1108694355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007284,
-    "geom:area_square_m":88963875.771955,
+    "geom:area_square_m":88963979.570259,
     "geom:bbox":"-70.725999,8.901178,-70.579584,9.027004",
     "geom:latitude":8.956352,
     "geom:longitude":-70.65384,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.ME.PL",
         "wd:id":"Q2096564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415780,
-    "wof:geomhash":"4fc1c603cfcd8c65e8a7c9411ce1faa7",
+    "wof:geomhash":"8f1fd225a39750f91408d17ba1718b81",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694355,
-    "wof:lastmodified":1690915023,
+    "wof:lastmodified":1695886380,
     "wof:name":"Pueblo Llano",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/435/7/1108694357.geojson
+++ b/data/110/869/435/7/1108694357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050801,
-    "geom:area_square_m":618623286.381923,
+    "geom:area_square_m":618623289.450553,
     "geom:bbox":"-63.327142,9.887908,-62.934245,10.122384",
     "geom:latitude":9.99922,
     "geom:longitude":-63.140394,
@@ -118,9 +118,10 @@
         "hasc:id":"VE.MO.PU",
         "wd:id":"Q2064667"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415782,
-    "wof:geomhash":"95e55a46db8dc1df667739fde0ac4ea2",
+    "wof:geomhash":"d36c1fa0489b7b6caeea180c01108a4d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108694357,
-    "wof:lastmodified":1690915023,
+    "wof:lastmodified":1695886380,
     "wof:name":"Punceres",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/435/9/1108694359.geojson
+++ b/data/110/869/435/9/1108694359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00944,
-    "geom:area_square_m":115172114.013911,
+    "geom:area_square_m":115172097.196053,
     "geom:bbox":"-70.80936,9.2706,-70.656326,9.41",
     "geom:latitude":9.351086,
     "geom:longitude":-70.726432,
@@ -90,9 +90,10 @@
         "hasc:id":"VE.TR.RR",
         "wd:id":"Q2465345"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415784,
-    "wof:geomhash":"6f753b70aacef57dabc178459f7e5a90",
+    "wof:geomhash":"f54aa6d6fb30bcee815d415821f3ac64",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108694359,
-    "wof:lastmodified":1690915022,
+    "wof:lastmodified":1695886380,
     "wof:name":"Rafael Rangel",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/436/1/1108694361.geojson
+++ b/data/110/869/436/1/1108694361.geojson
@@ -104,6 +104,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415785,
     "wof:geomhash":"a2237035e09145f5ebc9c65bf03677a9",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108694361,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886372,
     "wof:name":"Rafael Urdaneta",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/436/3/1108694363.geojson
+++ b/data/110/869/436/3/1108694363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015751,
-    "geom:area_square_m":193085980.294002,
+    "geom:area_square_m":193085486.299309,
     "geom:bbox":"-72.47672,7.399442,-72.380801,7.695367",
     "geom:latitude":7.531331,
     "geom:longitude":-72.430705,
@@ -97,9 +97,10 @@
         "hasc:id":"VE.TA.RU",
         "wd:id":"Q1833236"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415788,
-    "wof:geomhash":"d7607e70c088c7085c3f3aca82fe9a6b",
+    "wof:geomhash":"a923a8e01d22ba145ed7ce2dcff318dd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108694363,
-    "wof:lastmodified":1690914997,
+    "wof:lastmodified":1695886372,
     "wof:name":"Rafael Urdaneta",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/436/5/1108694365.geojson
+++ b/data/110/869/436/5/1108694365.geojson
@@ -93,7 +93,7 @@
         }
     ],
     "wof:id":1108694365,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886373,
     "wof:name":"Ribas",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/436/9/1108694369.geojson
+++ b/data/110/869/436/9/1108694369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07767,
-    "geom:area_square_m":947760488.067059,
+    "geom:area_square_m":947760434.185495,
     "geom:bbox":"-68.882858,9.059482,-68.406151,9.557721",
     "geom:latitude":9.305176,
     "geom:longitude":-68.634961,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.CO.RI",
         "wd:id":"Q2218342"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415792,
-    "wof:geomhash":"7623563bda24dadfa1ba80ea3a68359b",
+    "wof:geomhash":"7d26d36db09bb09a0040af1f1937f103",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694369,
-    "wof:lastmodified":1690914996,
+    "wof:lastmodified":1695886372,
     "wof:name":"Ricaurte",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/437/1/1108694371.geojson
+++ b/data/110/869/437/1/1108694371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.128654,
-    "geom:area_square_m":38668389836.999786,
+    "geom:area_square_m":38668389833.546524,
     "geom:bbox":"-67.102674,0.647529,-63.992444,2.82",
     "geom:latitude":1.684577,
     "geom:longitude":-65.756719,
@@ -196,9 +196,10 @@
         "hasc:id":"VE.AM.RN",
         "wd:id":"Q2198075"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415793,
-    "wof:geomhash":"dbb5f5a9fc5fd05a229d261a7ca0ff26",
+    "wof:geomhash":"2009d713baac91279fca35e53bf03bed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1108694371,
-    "wof:lastmodified":1690914994,
+    "wof:lastmodified":1695886193,
     "wof:name":"Rio Negro",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/110/869/437/3/1108694373.geojson
+++ b/data/110/869/437/3/1108694373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015072,
-    "geom:area_square_m":184437643.591294,
+    "geom:area_square_m":184437434.911996,
     "geom:bbox":"-71.910879,8.159247,-71.748829,8.330931",
     "geom:latitude":8.241466,
     "geom:longitude":-71.827996,
@@ -94,9 +94,10 @@
         "hasc:id":"VE.ME.RD",
         "wd:id":"Q2291411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415796,
-    "wof:geomhash":"c468d02670a7860d04a37cd80b8c4562",
+    "wof:geomhash":"1e99ada86602da5442335880c3a771da",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108694373,
-    "wof:lastmodified":1690914994,
+    "wof:lastmodified":1695886372,
     "wof:name":"Rivas Davila",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/437/5/1108694375.geojson
+++ b/data/110/869/437/5/1108694375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136775,
-    "geom:area_square_m":1672626311.035405,
+    "geom:area_square_m":1672626317.28599,
     "geom:bbox":"-69.916713,8.209471,-69.470077,8.743422",
     "geom:latitude":8.510169,
     "geom:longitude":-69.647041,
@@ -105,9 +105,10 @@
         "hasc:id":"VE.BA.RO",
         "wd:id":"Q1956852"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415797,
-    "wof:geomhash":"f99f26f337627e05e35a659e0b1c825c",
+    "wof:geomhash":"5b9a8e6ef2438c8a95e92b384ebbff74",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108694375,
-    "wof:lastmodified":1690914995,
+    "wof:lastmodified":1695886194,
     "wof:name":"Rojas",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/110/869/437/7/1108694377.geojson
+++ b/data/110/869/437/7/1108694377.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CO.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415799,
     "wof:geomhash":"fa0ba60b9cb63661ea1512732fbda383",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694377,
-    "wof:lastmodified":1694492880,
+    "wof:lastmodified":1695886392,
     "wof:name":"Romulo Gallegos",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/437/9/1108694379.geojson
+++ b/data/110/869/437/9/1108694379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.278291,
-    "geom:area_square_m":3385917117.529515,
+    "geom:area_square_m":3385917117.530401,
     "geom:bbox":"-72.8590272738,9.839583397,-71.9812518202,10.6226135051",
     "geom:latitude":10.275845,
     "geom:longitude":-72.353654,
@@ -83,9 +83,10 @@
         "hasc:id":"VE.ZU.RP",
         "wd:id":"Q1996591"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415806,
-    "wof:geomhash":"64a6e4213e94390497a7e64ea8c58cf3",
+    "wof:geomhash":"d1fa851312a08eff7829c0d20f072855",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108694379,
-    "wof:lastmodified":1566645802,
+    "wof:lastmodified":1695886372,
     "wof:name":"Rosario De Perija",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/438/1/1108694381.geojson
+++ b/data/110/869/438/1/1108694381.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"VE.BO.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415809,
     "wof:geomhash":"01d4c51609fb39ddbbc3e776121f816b",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108694381,
-    "wof:lastmodified":1694492881,
+    "wof:lastmodified":1695886393,
     "wof:name":"Roscio",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/438/3/1108694383.geojson
+++ b/data/110/869/438/3/1108694383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111727,
-    "geom:area_square_m":1358668707.624722,
+    "geom:area_square_m":1358668866.793431,
     "geom:bbox":"-63.766976,10.198333,-63.328123,10.659555",
     "geom:latitude":10.435741,
     "geom:longitude":-63.578233,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.SU.RI",
         "wd:id":"Q3071700"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415810,
-    "wof:geomhash":"3abc969935a92a0a315ed0e13921e325",
+    "wof:geomhash":"fbcbf93b907cc37528ebc0f990491eb3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694383,
-    "wof:lastmodified":1690915001,
+    "wof:lastmodified":1695886374,
     "wof:name":"Rubero",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/438/7/1108694387.geojson
+++ b/data/110/869/438/7/1108694387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040217,
-    "geom:area_square_m":489771420.351819,
+    "geom:area_square_m":489771228.682264,
     "geom:bbox":"-67.101372,9.888182,-66.719103,10.076821",
     "geom:latitude":9.974132,
     "geom:longitude":-66.944749,
@@ -136,9 +136,10 @@
         "hasc:id":"VE.AR.SC",
         "wd:id":"Q2475546"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415813,
-    "wof:geomhash":"35dd6e2045735e512fa11aa83d2be04f",
+    "wof:geomhash":"c84824e70e13cb84bf3050d726266b5f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108694387,
-    "wof:lastmodified":1690915001,
+    "wof:lastmodified":1695886374,
     "wof:name":"San Casimiro",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/438/9/1108694389.geojson
+++ b/data/110/869/438/9/1108694389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.462289,
-    "geom:area_square_m":5666653034.93588,
+    "geom:area_square_m":5666653393.403642,
     "geom:bbox":"-67.52463,7.176152,-66.327632,7.911003",
     "geom:latitude":7.554817,
     "geom:longitude":-66.947605,
@@ -133,9 +133,10 @@
         "hasc:id":"VE.AP.SF",
         "wd:id":"Q3471417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415817,
-    "wof:geomhash":"a92f814622701eb61df87995714ee5a9",
+    "wof:geomhash":"38ae504e9045571ee4f9ec3ded9040b7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108694389,
-    "wof:lastmodified":1690915000,
+    "wof:lastmodified":1695886194,
     "wof:name":"San Fernando",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/110/869/439/1/1108694391.geojson
+++ b/data/110/869/439/1/1108694391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013518,
-    "geom:area_square_m":164322513.050334,
+    "geom:area_square_m":164322454.627258,
     "geom:bbox":"-71.779967,10.509473,-71.607941,10.61",
     "geom:latitude":10.555273,
     "geom:longitude":-71.700144,
@@ -543,9 +543,10 @@
     "wof:concordances":{
         "hasc:id":"VE.FA.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415821,
-    "wof:geomhash":"765eae4d650e6cd500da518c2c803463",
+    "wof:geomhash":"c39b77b9cae9048c7b3cb0a6c0ef61f3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -555,7 +556,7 @@
         }
     ],
     "wof:id":1108694391,
-    "wof:lastmodified":1636506206,
+    "wof:lastmodified":1695886193,
     "wof:name":"San Francisco",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/439/3/1108694393.geojson
+++ b/data/110/869/439/3/1108694393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098466,
-    "geom:area_square_m":1202808278.912713,
+    "geom:area_square_m":1202808278.912679,
     "geom:bbox":"-70.1930678724,8.71343442356,-69.6134219409,9.17988675027",
     "geom:latitude":8.924064,
     "geom:longitude":-69.91982,
@@ -86,9 +86,10 @@
         "hasc:id":"VE.PO.SG",
         "wd:id":"Q2557299"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415822,
-    "wof:geomhash":"bf9d5555bf76b8f356b0c38852e293df",
+    "wof:geomhash":"4d305938edb9cc82f8b600f9b0e5a247",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694393,
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1695886371,
     "wof:name":"San Genaro De Boconoito",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/439/5/1108694395.geojson
+++ b/data/110/869/439/5/1108694395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330554,
-    "geom:area_square_m":4047411963.777532,
+    "geom:area_square_m":4047411363.389447,
     "geom:bbox":"-67.511648,7.697238,-66.53,8.451043",
     "geom:latitude":8.015621,
     "geom:longitude":-67.085093,
@@ -122,9 +122,10 @@
         "hasc:id":"VE.GU.SG",
         "wd:id":"Q639423"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415824,
-    "wof:geomhash":"fa4d5be7b7ceed8f5d030579d590b4d9",
+    "wof:geomhash":"aa1fe8fe9d8e1d4a6efd41120ab206c7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108694395,
-    "wof:lastmodified":1690914992,
+    "wof:lastmodified":1695886372,
     "wof:name":"San Geronimo De Guayabal",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/439/7/1108694397.geojson
+++ b/data/110/869/439/7/1108694397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089368,
-    "geom:area_square_m":1088965825.853253,
+    "geom:area_square_m":1088965710.833849,
     "geom:bbox":"-65.9867,9.5875,-65.669356,9.971755",
     "geom:latitude":9.787662,
     "geom:longitude":-65.841433,
@@ -128,9 +128,10 @@
         "hasc:id":"VE.GU.SJ",
         "wd:id":"Q1581067"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415827,
-    "wof:geomhash":"fe82d3843b9b973aeda1f6ab9328068f",
+    "wof:geomhash":"f64b97e8839da9ff0c4ba77bde467eaa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108694397,
-    "wof:lastmodified":1690914991,
+    "wof:lastmodified":1695886371,
     "wof:name":"San Jose De Guaribe",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/439/9/1108694399.geojson
+++ b/data/110/869/439/9/1108694399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019698,
-    "geom:area_square_m":241043205.468128,
+    "geom:area_square_m":241043054.098694,
     "geom:bbox":"-72.154166,8.187562,-71.95033,8.343283",
     "geom:latitude":8.263188,
     "geom:longitude":-72.040672,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TA.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415830,
-    "wof:geomhash":"c32aa3f34793b950a83635f0cf779737",
+    "wof:geomhash":"9d8abb3e2e0acaae382697c5ddf0a96c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694399,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886182,
     "wof:name":"San Judas Tadeo",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/440/1/1108694401.geojson
+++ b/data/110/869/440/1/1108694401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007093,
-    "geom:area_square_m":86538326.360221,
+    "geom:area_square_m":86538326.360245,
     "geom:bbox":"-70.6027736228,9.26166666667,-70.5386633462,9.45357137883",
     "geom:latitude":9.359889,
     "geom:longitude":-70.571044,
@@ -83,9 +83,10 @@
         "hasc:id":"VE.TR.SR",
         "wd:id":"Q1905292"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415831,
-    "wof:geomhash":"c1369d04169d2883b90d3f023ffa36eb",
+    "wof:geomhash":"6454434d44a548ad19d709bad3b678af",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108694401,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1695886367,
     "wof:name":"San Rafael De Carvajal",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/440/5/1108694405.geojson
+++ b/data/110/869/440/5/1108694405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018058,
-    "geom:area_square_m":220121262.55611,
+    "geom:area_square_m":220121465.163752,
     "geom:bbox":"-69.083703,9.547034,-68.91,9.77",
     "geom:latitude":9.661142,
     "geom:longitude":-68.993511,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.PO.AB",
         "wd:id":"Q2827311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415833,
-    "wof:geomhash":"a2678f1dc13f563d61ef63d85de024d3",
+    "wof:geomhash":"ed4b2a9f93f1c180486eacdc427e6971",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694405,
-    "wof:lastmodified":1690914977,
+    "wof:lastmodified":1695886367,
     "wof:name":"San Rafael De Onoto",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/440/7/1108694407.geojson
+++ b/data/110/869/440/7/1108694407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041626,
-    "geom:area_square_m":506901183.920021,
+    "geom:area_square_m":506901502.58639,
     "geom:bbox":"-67.325672,9.831749,-67.058546,10.102069",
     "geom:latitude":9.997392,
     "geom:longitude":-67.182849,
@@ -128,9 +128,10 @@
         "hasc:id":"VE.AR.SS",
         "wd:id":"Q642788"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415834,
-    "wof:geomhash":"dc0c2f598ecb973340569a7d282a7713",
+    "wof:geomhash":"20b4610a251e315237f9ca09afd2fe3f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108694407,
-    "wof:lastmodified":1690914976,
+    "wof:lastmodified":1695886367,
     "wof:name":"San Sebastian",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/440/9/1108694409.geojson
+++ b/data/110/869/440/9/1108694409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06466,
-    "geom:area_square_m":789118995.588863,
+    "geom:area_square_m":789119002.826725,
     "geom:bbox":"-64.768702,9.059883,-64.451272,9.473018",
     "geom:latitude":9.257058,
     "geom:longitude":-64.619672,
@@ -198,9 +198,10 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415836,
-    "wof:geomhash":"c0276357dedf98d36c229659f61ea654",
+    "wof:geomhash":"8d507c24f675260825bf348716c80e92",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1108694409,
-    "wof:lastmodified":1636506204,
+    "wof:lastmodified":1695886191,
     "wof:name":"Santa Ana",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/110/869/441/1/1108694411.geojson
+++ b/data/110/869/441/1/1108694411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025094,
-    "geom:area_square_m":305968588.965348,
+    "geom:area_square_m":305968566.373464,
     "geom:bbox":"-63.640527,9.49802,-63.448585,9.649037",
     "geom:latitude":9.572905,
     "geom:longitude":-63.542598,
@@ -159,9 +159,10 @@
         "hasc:id":"VE.MO.SB",
         "wd:id":"Q3472583"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415838,
-    "wof:geomhash":"c58c9ef761232adfef16e72069484cf5",
+    "wof:geomhash":"bb2b89fad01d63e5ee50319e8d918cea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1108694411,
-    "wof:lastmodified":1690914985,
+    "wof:lastmodified":1695886191,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/441/3/1108694413.geojson
+++ b/data/110/869/441/3/1108694413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372635,
-    "geom:area_square_m":4555552136.774262,
+    "geom:area_square_m":4555551657.859741,
     "geom:bbox":"-65.612591,7.859673,-64.788012,9.085018",
     "geom:latitude":8.624301,
     "geom:longitude":-65.320124,
@@ -125,9 +125,10 @@
         "hasc:id":"VE.GU.SM",
         "wd:id":"Q1581813"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415840,
-    "wof:geomhash":"747ada2c8af3eb1f36aa8d225f8e64b5",
+    "wof:geomhash":"07abc2abe4bfd5f13e6c2d774dbc7d66",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108694413,
-    "wof:lastmodified":1690914986,
+    "wof:lastmodified":1695886370,
     "wof:name":"Santa Maria De Ipire",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/441/5/1108694415.geojson
+++ b/data/110/869/441/5/1108694415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041598,
-    "geom:area_square_m":505701561.473345,
+    "geom:area_square_m":505701528.822821,
     "geom:bbox":"-71.540443,10.441709,-71.151647,10.620445",
     "geom:latitude":10.528578,
     "geom:longitude":-71.365525,
@@ -144,9 +144,10 @@
         "hasc:id":"VE.ZU.SR",
         "wd:id":"Q2471594"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415842,
-    "wof:geomhash":"313149698b4ef56cdda55714ebd0ab42",
+    "wof:geomhash":"fb17258104c56bb589d156cbc92b834f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108694415,
-    "wof:lastmodified":1690914986,
+    "wof:lastmodified":1695886192,
     "wof:name":"Santa Rita",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/441/7/1108694417.geojson
+++ b/data/110/869/441/7/1108694417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098365,
-    "geom:area_square_m":1201323356.573517,
+    "geom:area_square_m":1201323675.353568,
     "geom:bbox":"-69.107642,8.831823,-68.565118,9.229465",
     "geom:latitude":8.999286,
     "geom:longitude":-68.872177,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"VE.PO.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415843,
-    "wof:geomhash":"539347085140e4ab289f28b0976cfd57",
+    "wof:geomhash":"31d1e32cf8d355f6de58fb9fa0bb6e3d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108694417,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886182,
     "wof:name":"Santa Rosalia",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/441/9/1108694419.geojson
+++ b/data/110/869/441/9/1108694419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017277,
-    "geom:area_square_m":210265584.965654,
+    "geom:area_square_m":210265749.207634,
     "geom:bbox":"-67.21,10.077917,-67.098025,10.311667",
     "geom:latitude":10.190104,
     "geom:longitude":-67.158144,
@@ -145,9 +145,10 @@
         "hasc:id":"VE.AR.SA",
         "wd:id":"Q3042211"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415846,
-    "wof:geomhash":"28ab99698c0a50ca5fb1b59b71144851",
+    "wof:geomhash":"77615e3b346586213bee9c807b3d9266",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108694419,
-    "wof:lastmodified":1690914985,
+    "wof:lastmodified":1695886369,
     "wof:name":"Santos Michelena",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/442/3/1108694423.geojson
+++ b/data/110/869/442/3/1108694423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011141,
-    "geom:area_square_m":136377276.087653,
+    "geom:area_square_m":136376996.821718,
     "geom:bbox":"-72.176288,8.076463,-72.021542,8.218411",
     "geom:latitude":8.135386,
     "geom:longitude":-72.089764,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.TA.SE",
         "wd:id":"Q2015236"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415848,
-    "wof:geomhash":"6dc05c31347fd7cfc3304b957ddf63fe",
+    "wof:geomhash":"d96620897addd89a8294ad58ae5c860d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694423,
-    "wof:lastmodified":1690915016,
+    "wof:lastmodified":1695886379,
     "wof:name":"Seboruco",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/442/5/1108694425.geojson
+++ b/data/110/869/442/5/1108694425.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AN.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415852,
     "wof:geomhash":"531189194401944a9b7404489f7d8f9b",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694425,
-    "wof:lastmodified":1694492884,
+    "wof:lastmodified":1695886399,
     "wof:name":"Simon Bolivar",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/110/869/442/7/1108694427.geojson
+++ b/data/110/869/442/7/1108694427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070247,
-    "geom:area_square_m":855858238.023073,
+    "geom:area_square_m":855858358.33069,
     "geom:bbox":"-69.282172,9.679737,-68.950178,10.0192",
     "geom:latitude":9.832616,
     "geom:longitude":-69.11612,
@@ -122,9 +122,10 @@
         "hasc:id":"VE.LA.SP",
         "wd:id":"Q3088394"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415854,
-    "wof:geomhash":"678dbfb617f45238de491402451d0da7",
+    "wof:geomhash":"4a5e0558e395a7606e7836ff5a18b207",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108694427,
-    "wof:lastmodified":1690915015,
+    "wof:lastmodified":1695886379,
     "wof:name":"Simon Planas",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/110/869/442/9/1108694429.geojson
+++ b/data/110/869/442/9/1108694429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005224,
-    "geom:area_square_m":63907977.548963,
+    "geom:area_square_m":63908075.007777,
     "geom:bbox":"-71.88803,8.276633,-71.799454,8.378817",
     "geom:latitude":8.331123,
     "geom:longitude":-71.848909,
@@ -98,9 +98,10 @@
         "hasc:id":"VE.TA.SR",
         "wd:id":"Q2772652"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415856,
-    "wof:geomhash":"463d351c5b48565736c39755bdf440f6",
+    "wof:geomhash":"0c2fa79574096f64478222b412b56c34",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108694429,
-    "wof:lastmodified":1690915015,
+    "wof:lastmodified":1695886379,
     "wof:name":"Simon Rodriguez",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/443/1/1108694431.geojson
+++ b/data/110/869/443/1/1108694431.geojson
@@ -114,6 +114,7 @@
     "wof:concordances":{
         "hasc:id":"VE.MO.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415859,
     "wof:geomhash":"4680a5b6825cbc565e1b187ca866e88d",
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108694431,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sotillo",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/443/3/1108694433.geojson
+++ b/data/110/869/443/3/1108694433.geojson
@@ -368,6 +368,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415861,
     "wof:geomhash":"2181e39c56e2af127688a696b4b6c223",
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":1108694433,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/443/5/1108694435.geojson
+++ b/data/110/869/443/5/1108694435.geojson
@@ -369,6 +369,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415863,
     "wof:geomhash":"3a9aa9efe9a959182a87a93489837543",
@@ -381,7 +382,7 @@
         }
     ],
     "wof:id":1108694435,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886378,
     "wof:name":"Sucre",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/443/7/1108694437.geojson
+++ b/data/110/869/443/7/1108694437.geojson
@@ -368,6 +368,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415864,
     "wof:geomhash":"8ea76b152e73073a0e996707176bbcdb",
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":1108694437,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/444/1/1108694441.geojson
+++ b/data/110/869/444/1/1108694441.geojson
@@ -368,6 +368,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415866,
     "wof:geomhash":"896dfed0705fc6c5f6495d0d75ad10db",
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":1108694441,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/444/3/1108694443.geojson
+++ b/data/110/869/444/3/1108694443.geojson
@@ -368,6 +368,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415867,
     "wof:geomhash":"ec184f7d5ab41bd1241796642a25130f",
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":1108694443,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/444/5/1108694445.geojson
+++ b/data/110/869/444/5/1108694445.geojson
@@ -368,6 +368,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.SU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415868,
     "wof:geomhash":"ab9a702d0dce701c06447e19dbce2992",
@@ -380,7 +381,7 @@
         }
     ],
     "wof:id":1108694445,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/110/869/444/7/1108694447.geojson
+++ b/data/110/869/444/7/1108694447.geojson
@@ -369,6 +369,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415870,
     "wof:geomhash":"80c0d790bce1f924d090efb3d1aa3f25",
@@ -381,7 +382,7 @@
         }
     ],
     "wof:id":1108694447,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/444/9/1108694449.geojson
+++ b/data/110/869/444/9/1108694449.geojson
@@ -369,6 +369,7 @@
     "wof:concordances":{
         "hasc:id":"VE.YA.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415871,
     "wof:geomhash":"68e828ea4ec0d3c69efac612c9b7c727",
@@ -381,7 +382,7 @@
         }
     ],
     "wof:id":1108694449,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886377,
     "wof:name":"Sucre",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/445/1/1108694451.geojson
+++ b/data/110/869/445/1/1108694451.geojson
@@ -72,6 +72,7 @@
     "wof:concordances":{
         "hasc:id":"VE.CO.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415873,
     "wof:geomhash":"4e8b88269e157e97628fd4c9e6c29852",
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108694451,
-    "wof:lastmodified":1694492405,
+    "wof:lastmodified":1695886379,
     "wof:name":"Tinaco",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/110/869/445/3/1108694453.geojson
+++ b/data/110/869/445/3/1108694453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.605108,
-    "geom:area_square_m":7364571106.716879,
+    "geom:area_square_m":7364571158.676744,
     "geom:bbox":"-70.877193,9.76419,-69.609404,10.566717",
     "geom:latitude":10.17504,
     "geom:longitude":-70.204047,
@@ -124,9 +124,10 @@
         "hasc:id":"VE.LA.TO",
         "wd:id":"Q3132001"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415877,
-    "wof:geomhash":"c196828a49352edd12d6640aa671af82",
+    "wof:geomhash":"63f1f17f3dc639db64d0b283c1118d1d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108694453,
-    "wof:lastmodified":1690915017,
+    "wof:lastmodified":1695886380,
     "wof:name":"Torres",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/110/869/445/5/1108694455.geojson
+++ b/data/110/869/445/5/1108694455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02409,
-    "geom:area_square_m":292979373.145989,
+    "geom:area_square_m":292979542.37034,
     "geom:bbox":"-67.472001,10.32,-67.161633,10.542889",
     "geom:latitude":10.406845,
     "geom:longitude":-67.334036,
@@ -109,9 +109,10 @@
         "hasc:id":"VE.AR.TO",
         "wd:id":"Q2421221"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415878,
-    "wof:geomhash":"8427932d6647a0d46cfbfb2bf3cbf591",
+    "wof:geomhash":"21ad38f3238a0d8cbdc886584a1368db",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108694455,
-    "wof:lastmodified":1690915017,
+    "wof:lastmodified":1695886380,
     "wof:name":"Tovar",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/110/869/445/9/1108694459.geojson
+++ b/data/110/869/445/9/1108694459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032832,
-    "geom:area_square_m":400949313.817603,
+    "geom:area_square_m":400949302.790762,
     "geom:bbox":"-71.233099,8.88289,-70.940419,9.201781",
     "geom:latitude":9.021271,
     "geom:longitude":-71.108892,
@@ -90,9 +90,10 @@
         "hasc:id":"VE.ME.TC",
         "wd:id":"Q2457287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415883,
-    "wof:geomhash":"fdb6b0b7b552d287dddcf19d7a92d725",
+    "wof:geomhash":"4c16f7192baaaad9c3cf66f6649be5f8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108694459,
-    "wof:lastmodified":1690915016,
+    "wof:lastmodified":1695886379,
     "wof:name":"Tulio Febres Cordero",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/446/1/1108694461.geojson
+++ b/data/110/869/446/1/1108694461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125231,
-    "geom:area_square_m":1528400932.926331,
+    "geom:area_square_m":1528400766.919019,
     "geom:bbox":"-69.19,8.990572,-68.62511,9.462825",
     "geom:latitude":9.242991,
     "geom:longitude":-68.897963,
@@ -96,9 +96,10 @@
         "hasc:id":"VE.PO.TU",
         "wd:id":"Q3038839"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415884,
-    "wof:geomhash":"17086eaf482dd8d9d6235c5a206a53bd",
+    "wof:geomhash":"5116761c71526cb49ea6d2fdd0362c10",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108694461,
-    "wof:lastmodified":1690914984,
+    "wof:lastmodified":1695886369,
     "wof:name":"Turen",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/110/869/446/3/1108694463.geojson
+++ b/data/110/869/446/3/1108694463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083401,
-    "geom:area_square_m":1012932169.455785,
+    "geom:area_square_m":1012932402.644318,
     "geom:bbox":"-69.351365,10.670187,-68.858172,11.065",
     "geom:latitude":10.819739,
     "geom:longitude":-69.15126,
@@ -91,9 +91,10 @@
         "hasc:id":"VE.FA.UN",
         "wd:id":"Q2024872"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415886,
-    "wof:geomhash":"480b871a7baa8cf6ea382f8c09325871",
+    "wof:geomhash":"b89c239528d39ec07af4f41b53d7f46f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108694463,
-    "wof:lastmodified":1690914984,
+    "wof:lastmodified":1695886370,
     "wof:name":"Union",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/446/5/1108694465.geojson
+++ b/data/110/869/446/5/1108694465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015175,
-    "geom:area_square_m":184678903.379025,
+    "geom:area_square_m":184679091.757798,
     "geom:bbox":"-69.078641,10.09848,-68.917472,10.330804",
     "geom:latitude":10.199962,
     "geom:longitude":-68.996005,
@@ -122,9 +122,10 @@
         "hasc:id":"VE.YA.UR",
         "wd:id":"Q1974420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415888,
-    "wof:geomhash":"1c978937ce126113d77c8388c9bd54e8",
+    "wof:geomhash":"78190d5d50ef5f9476e2896eb0e9f6ec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108694465,
-    "wof:lastmodified":1690914985,
+    "wof:lastmodified":1695886370,
     "wof:name":"Urachiche",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/446/7/1108694467.geojson
+++ b/data/110/869/446/7/1108694467.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"VE.MO.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415889,
     "wof:geomhash":"3a20f214db6287e00d67b8729a81dcac",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108694467,
-    "wof:lastmodified":1694492891,
+    "wof:lastmodified":1695886417,
     "wof:name":"Uracoa",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/110/869/446/9/1108694469.geojson
+++ b/data/110/869/446/9/1108694469.geojson
@@ -83,6 +83,7 @@
     "wof:concordances":{
         "hasc:id":"VE.AR.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415891,
     "wof:geomhash":"ea9f110d22eb327514515e1f269f3a6c",
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108694469,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886369,
     "wof:name":"Urdaneta",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/110/869/447/1/1108694471.geojson
+++ b/data/110/869/447/1/1108694471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074002,
-    "geom:area_square_m":897883868.855092,
+    "geom:area_square_m":897883868.855374,
     "geom:bbox":"-70.4359854075,10.8896964768,-70.1195478421,11.357110977",
     "geom:latitude":11.115629,
     "geom:longitude":-70.28363,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"VE.FA.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415895,
-    "wof:geomhash":"05f5521d2f31e70e730072169d1c0b26",
+    "wof:geomhash":"e42f5ca57b11abc971dc368ae5e8e6dc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108694471,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1695886367,
     "wof:name":"Urumaco",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/110/869/447/3/1108694473.geojson
+++ b/data/110/869/447/3/1108694473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048144,
-    "geom:area_square_m":585062190.437411,
+    "geom:area_square_m":585062778.662578,
     "geom:bbox":"-62.470752,10.534555,-61.851196,10.746166",
     "geom:latitude":10.647077,
     "geom:longitude":-62.234553,
@@ -147,9 +147,10 @@
         "hasc:id":"VE.SU.VA",
         "wd:id":"Q2230534"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415897,
-    "wof:geomhash":"5559e6c355423d04d7e7b7f02fe4a625",
+    "wof:geomhash":"5873627b2d185d67aa3fd2a538708c5c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108694473,
-    "wof:lastmodified":1690914978,
+    "wof:lastmodified":1695886191,
     "wof:name":"Valdez",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/110/869/447/7/1108694477.geojson
+++ b/data/110/869/447/7/1108694477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022329,
-    "geom:area_square_m":272554123.433697,
+    "geom:area_square_m":272554229.496423,
     "geom:bbox":"-70.784946,9.05446,-70.588333,9.356461",
     "geom:latitude":9.193076,
     "geom:longitude":-70.676595,
@@ -122,9 +122,10 @@
     "wof:concordances":{
         "hasc:id":"VE.TR.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415900,
-    "wof:geomhash":"35c72eb6b2e759e42fd6ce952b94da67",
+    "wof:geomhash":"cfc42875a66fd24b88ccbe8cc8c6d4f7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108694477,
-    "wof:lastmodified":1636506204,
+    "wof:lastmodified":1695886191,
     "wof:name":"Valera",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/110/869/447/9/1108694479.geojson
+++ b/data/110/869/447/9/1108694479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094452,
-    "geom:area_square_m":1149568959.366736,
+    "geom:area_square_m":1149568912.906437,
     "geom:bbox":"-71.227121,9.878232,-70.760431,10.471667",
     "geom:latitude":10.168091,
     "geom:longitude":-70.98117,
@@ -91,9 +91,10 @@
         "hasc:id":"VE.ZU.VR",
         "wd:id":"Q9298782"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415901,
-    "wof:geomhash":"65c04ba3d7385f4ee21d4191d2fdfff4",
+    "wof:geomhash":"6732c366a98ef622d809c772856530d7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108694479,
-    "wof:lastmodified":1690914977,
+    "wof:lastmodified":1695886367,
     "wof:name":"Valmore Rodriguez",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/110/869/448/1/1108694481.geojson
+++ b/data/110/869/448/1/1108694481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079526,
-    "geom:area_square_m":967080100.226922,
+    "geom:area_square_m":967080048.224381,
     "geom:bbox":"-68.637292,10.209345,-68.26,10.608206",
     "geom:latitude":10.439593,
     "geom:longitude":-68.510605,
@@ -125,9 +125,10 @@
         "hasc:id":"VE.YA.VE",
         "wd:id":"Q1827306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415903,
-    "wof:geomhash":"0e8ca397fbfaa098c4647925c0e8bc17",
+    "wof:geomhash":"73c6884279657b0f6b02c7348e2a9843",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108694481,
-    "wof:lastmodified":1690914982,
+    "wof:lastmodified":1695886369,
     "wof:name":"Veroes",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/110/869/448/3/1108694483.geojson
+++ b/data/110/869/448/3/1108694483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.251559,
-    "geom:area_square_m":3070398858.201017,
+    "geom:area_square_m":3070398354.300284,
     "geom:bbox":"-65.629816,8.807917,-64.773693,9.652091",
     "geom:latitude":9.216915,
     "geom:longitude":-65.292573,
@@ -122,7 +122,7 @@
     },
     "wof:country":"VE",
     "wof:created":1474415908,
-    "wof:geomhash":"b3f565602901daba6cef9b0a68097624",
+    "wof:geomhash":"b006a2631a546dc07a3f0e839707eec8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -132,7 +132,7 @@
         }
     ],
     "wof:id":1108694483,
-    "wof:lastmodified":1690914983,
+    "wof:lastmodified":1695886191,
     "wof:name":"Zaraza",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/110/869/448/5/1108694485.geojson
+++ b/data/110/869/448/5/1108694485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010461,
-    "geom:area_square_m":127951296.136654,
+    "geom:area_square_m":127951264.864787,
     "geom:bbox":"-71.818205,8.337638,-71.70812,8.519674",
     "geom:latitude":8.430169,
     "geom:longitude":-71.762885,
@@ -93,9 +93,10 @@
         "hasc:id":"VE.ME.ZE",
         "wd:id":"Q2526746"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415910,
-    "wof:geomhash":"9e7c09f1bc7b1644fa796c3a1ccbada6",
+    "wof:geomhash":"77f58776ab09116894842ce9c45d1012",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108694485,
-    "wof:lastmodified":1690914983,
+    "wof:lastmodified":1695886369,
     "wof:name":"Zea",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/110/869/448/7/1108694487.geojson
+++ b/data/110/869/448/7/1108694487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.055337,
-    "geom:area_square_m":25358815856.401623,
+    "geom:area_square_m":25358815856.403465,
     "geom:bbox":"-67.8419378832,2.98076751273,-65.6775,4.88032031563",
     "geom:latitude":3.775967,
     "geom:longitude":-66.723736,
@@ -98,9 +98,10 @@
         "hasc:id":"VE.AM.AB",
         "wd:id":"Q2084824"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415912,
-    "wof:geomhash":"18517daa18c911256bc7473733d49cdb",
+    "wof:geomhash":"1333d8820ee593bff2fa5d3509524906",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108694487,
-    "wof:lastmodified":1566645793,
+    "wof:lastmodified":1695886369,
     "wof:name":"Atabapo",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/110/869/448/9/1108694489.geojson
+++ b/data/110/869/448/9/1108694489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26311,
-    "geom:area_square_m":3207001037.142614,
+    "geom:area_square_m":3207001094.577879,
     "geom:bbox":"-62.441104,9.372092,-61.799265,10.057889",
     "geom:latitude":9.68797,
     "geom:longitude":-62.111578,
@@ -141,9 +141,10 @@
         "hasc:id":"VE.DA.PE",
         "wd:id":"Q2552137"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1474415914,
-    "wof:geomhash":"0cc00f1cae43a05cb679edd2b6af9018",
+    "wof:geomhash":"5290bc66956533f1bd40911ae4d865aa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108694489,
-    "wof:lastmodified":1690914982,
+    "wof:lastmodified":1695886191,
     "wof:name":"Pedernales",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/151/183/838/3/1511838383.geojson
+++ b/data/151/183/838/3/1511838383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.59106,
-    "geom:area_square_m":2068355305.520315,
+    "geom:area_square_m":7273936953.876411,
     "geom:bbox":"-67.85135,4.949197,-66.449295,6.210163",
     "geom:latitude":5.574208,
     "geom:longitude":-67.317624,
@@ -65,8 +65,9 @@
         "hasc:id":"VE.AM.AR",
         "wd:id":"Q2295357"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
-    "wof:geomhash":"419ee4fee5f22a0f120570a87307ab73",
+    "wof:geomhash":"f77f218de0e51b1c8df770b3f298920a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1511838383,
-    "wof:lastmodified":1690914954,
+    "wof:lastmodified":1695886180,
     "wof:name":"Atures",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/421/166/695/421166695.geojson
+++ b/data/421/166/695/421166695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011568,
-    "geom:area_square_m":140421015.473039,
+    "geom:area_square_m":140421319.071265,
     "geom:bbox":"-64.036081,10.892754,-63.898652,11.055705",
     "geom:latitude":10.979635,
     "geom:longitude":-63.973216,
@@ -139,12 +139,13 @@
         "qs_pg:id":1263787,
         "wd:id":"Q2068516"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008699,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eda64417381aef24e9b378109ec9acf2",
+    "wof:geomhash":"968d5e2c9816a34fd6e1108103fc1ce4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421166695,
-    "wof:lastmodified":1690915026,
+    "wof:lastmodified":1695886188,
     "wof:name":"Diaz",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/166/897/421166897.geojson
+++ b/data/421/166/897/421166897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169963,
-    "geom:area_square_m":2068355305.520315,
+    "geom:area_square_m":2068355412.96799,
     "geom:bbox":"-66.563487,9.950228,-66.069963,10.529432",
     "geom:latitude":10.207329,
     "geom:longitude":-66.309721,
@@ -163,12 +163,13 @@
         "qs_pg:id":19940,
         "wd:id":"Q2625145"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008706,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c56aa248ab4715cd3bb93f5031cea63a",
+    "wof:geomhash":"ba283820d4ab85c0a8faf13e825b8fbd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421166897,
-    "wof:lastmodified":1690915027,
+    "wof:lastmodified":1695886188,
     "wof:name":"Acevedo",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/166/905/421166905.geojson
+++ b/data/421/166/905/421166905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261301,
-    "geom:area_square_m":3188074619.17135,
+    "geom:area_square_m":3188074046.162575,
     "geom:bbox":"-65.09324,8.834764,-64.35376,9.743794",
     "geom:latitude":9.350396,
     "geom:longitude":-64.770302,
@@ -151,12 +151,13 @@
         "qs_pg:id":43625,
         "wd:id":"Q606975"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008706,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ee66e5405ef0e4e1d80340d3a4f9540",
+    "wof:geomhash":"478c331d8e562a554c7b383e43fbf826",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421166905,
-    "wof:lastmodified":1690915026,
+    "wof:lastmodified":1695886195,
     "wof:name":"Aragua",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/169/209/421169209.geojson
+++ b/data/421/169/209/421169209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100773,
-    "geom:area_square_m":1224918454.092923,
+    "geom:area_square_m":1224918454.092955,
     "geom:bbox":"-67.408429,10.401632,-66.309735,11.87375",
     "geom:latitude":10.573778,
     "geom:longitude":-66.892359,
@@ -170,6 +170,7 @@
         "qs_pg:id":1199963,
         "wd:id":"Q3650762"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85680533
     ],
@@ -178,7 +179,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16d718e6f29752fafab38d083455ced5",
+    "wof:geomhash":"435afada2c4e866337f1966cf79f1f81",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":421169209,
-    "wof:lastmodified":1690915040,
+    "wof:lastmodified":1695886195,
     "wof:name":"Vargas",
     "wof:parent_id":85680533,
     "wof:placetype":"county",

--- a/data/421/169/421/421169421.geojson
+++ b/data/421/169/421/421169421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005126,
-    "geom:area_square_m":62719676.940974,
+    "geom:area_square_m":62719676.941016,
     "geom:bbox":"-71.8013578214,8.24961474848,-71.6877194227,8.37",
     "geom:latitude":8.300459,
     "geom:longitude":-71.743151,
@@ -112,12 +112,13 @@
         "qs_pg:id":1199962,
         "wd:id":"Q3535910"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008809,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a078c0ea2283565f410c3dcebdc592eb",
+    "wof:geomhash":"7f262f250a6536144c394cdf14032941",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421169421,
-    "wof:lastmodified":1582393017,
+    "wof:lastmodified":1695886189,
     "wof:name":"Tovar",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/169/951/421169951.geojson
+++ b/data/421/169/951/421169951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128419,
-    "geom:area_square_m":1558382485.985754,
+    "geom:area_square_m":1558382710.650223,
     "geom:bbox":"-69.87224,10.91138,-69.199933,11.233957",
     "geom:latitude":11.068968,
     "geom:longitude":-69.509848,
@@ -125,12 +125,13 @@
         "qs_pg:id":772404,
         "wd:id":"Q281921"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008830,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"45b42e99b0c324cd7b444c1eeb8e1929",
+    "wof:geomhash":"ae1eaaf74c8bfb16fc4b4c532be48989",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421169951,
-    "wof:lastmodified":1690915039,
+    "wof:lastmodified":1695886190,
     "wof:name":"Petit",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/170/033/421170033.geojson
+++ b/data/421/170/033/421170033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002762,
-    "geom:area_square_m":33526222.472394,
+    "geom:area_square_m":33526328.055168,
     "geom:bbox":"-63.899667,10.88625,-63.815326,10.995",
     "geom:latitude":10.956742,
     "geom:longitude":-63.858911,
@@ -302,12 +302,13 @@
         "qs_pg:id":1263798,
         "wd:id":"Q9029259"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8af543cc183f435db66284536ba18dd",
+    "wof:geomhash":"0e74ca91d4d97ef573e7454d4dd0987a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -317,7 +318,7 @@
         }
     ],
     "wof:id":421170033,
-    "wof:lastmodified":1690915107,
+    "wof:lastmodified":1695886197,
     "wof:name":"Mari\u00f1o",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/035/421170035.geojson
+++ b/data/421/170/035/421170035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005614,
-    "geom:area_square_m":68158112.948402,
+    "geom:area_square_m":68158320.899332,
     "geom:bbox":"-63.940992,10.885389,-63.855,11.000125",
     "geom:latitude":10.955389,
     "geom:longitude":-63.907151,
@@ -182,12 +182,13 @@
         "qs_pg:id":1263799,
         "wd:id":"Q2029662"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008834,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b112d820f0bc0ee29bfb03bd13915403",
+    "wof:geomhash":"c82c499c7ed47abe5a2b88e2c859ffb4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":421170035,
-    "wof:lastmodified":1690915106,
+    "wof:lastmodified":1695886198,
     "wof:name":"Garcia",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/157/421170157.geojson
+++ b/data/421/170/157/421170157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004683,
-    "geom:area_square_m":56841467.170414,
+    "geom:area_square_m":56841435.74606,
     "geom:bbox":"-63.907254,10.995,-63.80282,11.073692",
     "geom:latitude":11.0346,
     "geom:longitude":-63.857575,
@@ -103,12 +103,13 @@
         "qs_pg:id":221566,
         "wd:id":"Q418835"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008840,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d344d3fcfa468c39acc4f1a048dfb2ce",
+    "wof:geomhash":"54e33b149821bd7eeb58e1ba15e1328c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421170157,
-    "wof:lastmodified":1690915106,
+    "wof:lastmodified":1695886198,
     "wof:name":"Arismendi",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/170/247/421170247.geojson
+++ b/data/421/170/247/421170247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024587,
-    "geom:area_square_m":299289786.844562,
+    "geom:area_square_m":299289947.304139,
     "geom:bbox":"-66.991324,10.00854,-66.834324,10.24",
     "geom:latitude":10.12078,
     "geom:longitude":-66.909078,
@@ -112,12 +112,13 @@
         "qs_pg:id":231706,
         "wd:id":"Q403816"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008845,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8ba09f6132737ebc3287a73cd9019fc",
+    "wof:geomhash":"a00e01dd63d2b3605e1d49d7cf1d845b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421170247,
-    "wof:lastmodified":1690915106,
+    "wof:lastmodified":1695886198,
     "wof:name":"Urdaneta",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/375/421171375.geojson
+++ b/data/421/171/375/421171375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018437,
-    "geom:area_square_m":225902515.632625,
+    "geom:area_square_m":225902476.900416,
     "geom:bbox":"-72.273315,7.676779,-72.073782,7.811445",
     "geom:latitude":7.739919,
     "geom:longitude":-72.181513,
@@ -134,12 +134,13 @@
         "qs_pg:id":1263772,
         "wd:id":"Q3471395"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d810275314994bc5b52f3219998026c",
+    "wof:geomhash":"c10ff8ab238c511d0b86a78bc9e6256c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421171375,
-    "wof:lastmodified":1690915120,
+    "wof:lastmodified":1695886197,
     "wof:name":"San Cristobal",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/171/377/421171377.geojson
+++ b/data/421/171/377/421171377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006513,
-    "geom:area_square_m":79198821.407232,
+    "geom:area_square_m":79199070.108579,
     "geom:bbox":"-66.898412,10.360128,-66.822807,10.491752",
     "geom:latitude":10.427352,
     "geom:longitude":-66.8642,
@@ -154,12 +154,13 @@
         "qs_pg:id":1263773,
         "wd:id":"Q761148"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8763e5721cee6f7036631528688576d",
+    "wof:geomhash":"4ff01abe8ee88d16e7db38bfb670f9e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":421171377,
-    "wof:lastmodified":1690915118,
+    "wof:lastmodified":1695886199,
     "wof:name":"Baruta",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/381/421171381.geojson
+++ b/data/421/171/381/421171381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014411,
-    "geom:area_square_m":175215811.783758,
+    "geom:area_square_m":175215553.936498,
     "geom:bbox":"-66.841459,10.398333,-66.68848,10.551651",
     "geom:latitude":10.486066,
     "geom:longitude":-66.764434,
@@ -478,12 +478,13 @@
         "qs_pg:id":1263775,
         "wd:id":"Q2907"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"072a0cce1c5152a33ad4b95475727fa4",
+    "wof:geomhash":"608ae6c9630785dfc663838c1bf37807",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -493,7 +494,7 @@
         }
     ],
     "wof:id":421171381,
-    "wof:lastmodified":1690915120,
+    "wof:lastmodified":1695886199,
     "wof:name":"Sucre",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/639/421171639.geojson
+++ b/data/421/171/639/421171639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.581356,
-    "geom:area_square_m":7120437808.471272,
+    "geom:area_square_m":7120437808.471161,
     "geom:bbox":"-64.2779585576,7.44042815965,-62.9902158133,8.32236506245",
     "geom:latitude":7.892576,
     "geom:longitude":-63.632033,
@@ -98,12 +98,13 @@
         "hasc:id":"VE.BO.HE",
         "qs_pg:id":1263770
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"741b0b972f0bba1c75d6cdcaa7fa057d",
+    "wof:geomhash":"6af5c0c10ebf3b563a2b0d823cb82b44",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421171639,
-    "wof:lastmodified":1582393027,
+    "wof:lastmodified":1695886199,
     "wof:name":"Heres",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/171/643/421171643.geojson
+++ b/data/421/171/643/421171643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051846,
-    "geom:area_square_m":630127108.792003,
+    "geom:area_square_m":630127587.766088,
     "geom:bbox":"-66.32,10.377857,-65.992483,11.827222",
     "geom:latitude":10.605481,
     "geom:longitude":-66.179063,
@@ -191,12 +191,13 @@
         "qs_pg:id":1263784,
         "wd:id":"Q260682"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02abe400d3bb55020b89cda3e0813995",
+    "wof:geomhash":"c43066f3883c7de166890c4d1ef2fb8f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421171643,
-    "wof:lastmodified":1690915117,
+    "wof:lastmodified":1695886198,
     "wof:name":"Brion",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/645/421171645.geojson
+++ b/data/421/171/645/421171645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009621,
-    "geom:area_square_m":117131619.714788,
+    "geom:area_square_m":117131619.714783,
     "geom:bbox":"-65.49,10.0315008528,-65.3462822789,10.1429406918",
     "geom:latitude":10.088468,
     "geom:longitude":-65.409164,
@@ -123,12 +123,13 @@
         "qs_pg:id":1263786,
         "wd:id":"Q2674109"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ca0f07a5ad8835263afeeac73bd1693",
+    "wof:geomhash":"81076796f99482ca1c76e83a41ad1e27",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421171645,
-    "wof:lastmodified":1582393026,
+    "wof:lastmodified":1695886198,
     "wof:name":"San Juan De Capistrano",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/171/647/421171647.geojson
+++ b/data/421/171/647/421171647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263197,
-    "geom:area_square_m":3221920710.944983,
+    "geom:area_square_m":3221920710.945031,
     "geom:bbox":"-71.0390559988,7.7625760721,-70.2999750977,8.59907010805",
     "geom:latitude":8.110258,
     "geom:longitude":-70.685728,
@@ -146,12 +146,13 @@
         "qs_pg:id":1263806,
         "wd:id":"Q2673923"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"641b48f8722ffc490f4a995764d02480",
+    "wof:geomhash":"53392979bdd48350cda27cc42c1f8208",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421171647,
-    "wof:lastmodified":1582393027,
+    "wof:lastmodified":1695886200,
     "wof:name":"Antonio Jose De Sucre",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/171/649/421171649.geojson
+++ b/data/421/171/649/421171649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.722307,
-    "geom:area_square_m":21147214611.504295,
+    "geom:area_square_m":21147213996.98851,
     "geom:bbox":"-69.538772,6.060355,-66.990559,7.72",
     "geom:latitude":6.778591,
     "geom:longitude":-67.896132,
@@ -134,12 +134,13 @@
         "qs_pg:id":1263807,
         "wd:id":"Q2574354"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0da36e2cb3cb8d5bc43efc64ca1fca72",
+    "wof:geomhash":"2416dcecd4d1877c2265523f0536d79d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421171649,
-    "wof:lastmodified":1690915119,
+    "wof:lastmodified":1695886200,
     "wof:name":"Pedro Camejo",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/171/651/421171651.geojson
+++ b/data/421/171/651/421171651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.140654,
-    "geom:area_square_m":13990125107.46349,
+    "geom:area_square_m":13990125107.463116,
     "geom:bbox":"-68.9537571011,6.53175113097,-67.7821100098,7.96691084262",
     "geom:latitude":7.288835,
     "geom:longitude":-68.436293,
@@ -142,12 +142,13 @@
         "qs_pg:id":1263808,
         "wd:id":"Q649153"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008901,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c633d0e5b1b15531a7dcf17882ea4f1a",
+    "wof:geomhash":"76005338295aeab380c434ecc7148b4a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421171651,
-    "wof:lastmodified":1582393027,
+    "wof:lastmodified":1695886200,
     "wof:name":"Achaguas",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/171/913/421171913.geojson
+++ b/data/421/171/913/421171913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013422,
-    "geom:area_square_m":163315515.239465,
+    "geom:area_square_m":163315511.933987,
     "geom:bbox":"-66.896506,10.168121,-66.759209,10.343823",
     "geom:latitude":10.258865,
     "geom:longitude":-66.83673,
@@ -137,12 +137,13 @@
         "qs_pg:id":1283131,
         "wd:id":"Q2112101"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008911,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4bed81df997f353e17def5693d008f70",
+    "wof:geomhash":"03521b89ffa6d5953012ab209afa27fc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421171913,
-    "wof:lastmodified":1690915118,
+    "wof:lastmodified":1695886200,
     "wof:name":"Cristobal Rojas",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/171/995/421171995.geojson
+++ b/data/421/171/995/421171995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026604,
-    "geom:area_square_m":323621209.769437,
+    "geom:area_square_m":323621539.949505,
     "geom:bbox":"-67.678044,10.187306,-67.529237,10.518794",
     "geom:latitude":10.34025,
     "geom:longitude":-67.599129,
@@ -116,12 +116,13 @@
         "qs_pg:id":1289851,
         "wd:id":"Q413588"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"baa99f74041934085e02813b9f6d40dc",
+    "wof:geomhash":"eaefae0b30337e6d9589ace79a3c8ae9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421171995,
-    "wof:lastmodified":1636506273,
+    "wof:lastmodified":1695886197,
     "wof:name":"Girardot",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/171/997/421171997.geojson
+++ b/data/421/171/997/421171997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037861,
-    "geom:area_square_m":463134641.601664,
+    "geom:area_square_m":463134581.474393,
     "geom:bbox":"-71.765415,8.269051,-71.550344,8.548813",
     "geom:latitude":8.403622,
     "geom:longitude":-71.650447,
@@ -124,12 +124,13 @@
         "qs_pg:id":1289852,
         "wd:id":"Q2146204"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40fdd7933fcd88939b452a157e2b4c70",
+    "wof:geomhash":"b3906b54ab8f0c59aabe571d54e8f674",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421171997,
-    "wof:lastmodified":1690915116,
+    "wof:lastmodified":1695886198,
     "wof:name":"Antonio Pinto Salinas",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/171/999/421171999.geojson
+++ b/data/421/171/999/421171999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050304,
-    "geom:area_square_m":615163393.243588,
+    "geom:area_square_m":615163393.243464,
     "geom:bbox":"-71.4007807188,8.31924926942,-71.1511003378,8.71645575353",
     "geom:latitude":8.51529,
     "geom:longitude":-71.280666,
@@ -111,12 +111,13 @@
         "hasc:id":"VE.ME.CE",
         "qs_pg:id":1289854
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008915,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d81f2fbb4f764642550b332bb51b557f",
+    "wof:geomhash":"47402e7b526899b62e10797ab6b90322",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421171999,
-    "wof:lastmodified":1582393026,
+    "wof:lastmodified":1695886198,
     "wof:name":"Campo Elias",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/172/277/421172277.geojson
+++ b/data/421/172/277/421172277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160522,
-    "geom:area_square_m":1954374876.782382,
+    "geom:area_square_m":1954374302.887807,
     "geom:bbox":"-68.969311,9.840833,-68.351699,10.371101",
     "geom:latitude":10.059491,
     "geom:longitude":-68.639789,
@@ -135,12 +135,13 @@
         "qs_pg:id":149596,
         "wd:id":"Q10801437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008929,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"788b49fa9b54aec6227e6481e5463a9d",
+    "wof:geomhash":"dade9fafe723af9ee5667f556dff22d2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421172277,
-    "wof:lastmodified":1690915068,
+    "wof:lastmodified":1695886193,
     "wof:name":"Nirgua",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/172/279/421172279.geojson
+++ b/data/421/172/279/421172279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045319,
-    "geom:area_square_m":551450911.825997,
+    "geom:area_square_m":551451449.603668,
     "geom:bbox":"-68.397122,10.0425,-68.139926,10.421041",
     "geom:latitude":10.241989,
     "geom:longitude":-68.257486,
@@ -110,12 +110,13 @@
         "qs_pg:id":149660,
         "wd:id":"Q814976"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008929,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a909e2d0931c7f5cca0e95b78eda54c",
+    "wof:geomhash":"100c23c27a61f627aa80a2f5038627cf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421172279,
-    "wof:lastmodified":1690915068,
+    "wof:lastmodified":1695886193,
     "wof:name":"Bejuma",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/172/589/421172589.geojson
+++ b/data/421/172/589/421172589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030401,
-    "geom:area_square_m":369404906.326868,
+    "geom:area_square_m":369404906.326882,
     "geom:bbox":"-71.780428,10.589081,-71.578781,10.777593",
     "geom:latitude":10.681672,
     "geom:longitude":-71.690158,
@@ -298,6 +298,7 @@
         "hasc:id":"VE.ZU.MC",
         "qs_pg:id":1314599
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         890442137
     ],
@@ -307,7 +308,7 @@
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"52b31617497f4cf24324e0ed866381ec",
+    "wof:geomhash":"a034bfdaf8902428db8226540aaf5b0c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -317,7 +318,7 @@
         }
     ],
     "wof:id":421172589,
-    "wof:lastmodified":1608755529,
+    "wof:lastmodified":1695886458,
     "wof:name":"Maracaibo",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/172/597/421172597.geojson
+++ b/data/421/172/597/421172597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06187,
-    "geom:area_square_m":753416360.476923,
+    "geom:area_square_m":753416360.476965,
     "geom:bbox":"-65.4052022868,9.80469976089,-64.8652581845,10.125389099",
     "geom:latitude":9.997245,
     "geom:longitude":-65.075848,
@@ -123,12 +123,13 @@
         "qs_pg:id":1314619,
         "wd:id":"Q2310580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c74f2cdecac063bfd5a4912d2fc517b",
+    "wof:geomhash":"db747982c16422accc505bd82974e422",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421172597,
-    "wof:lastmodified":1582393020,
+    "wof:lastmodified":1695886193,
     "wof:name":"Pe\u00f1alver",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/172/599/421172599.geojson
+++ b/data/421/172/599/421172599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002521,
-    "geom:area_square_m":30593238.0892,
+    "geom:area_square_m":30593163.025361,
     "geom:bbox":"-63.855,10.98125,-63.77589,11.039322",
     "geom:latitude":11.008512,
     "geom:longitude":-63.814899,
@@ -142,12 +142,13 @@
         "qs_pg:id":1314637,
         "wd:id":"Q3066174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c9f6839ebf271795ee0497a2db3bded",
+    "wof:geomhash":"17edb99212dec52fc89c678737e0c957",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421172599,
-    "wof:lastmodified":1690915067,
+    "wof:lastmodified":1695886193,
     "wof:name":"Maneiro",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/172/601/421172601.geojson
+++ b/data/421/172/601/421172601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047081,
-    "geom:area_square_m":572229912.189574,
+    "geom:area_square_m":572229543.631494,
     "geom:bbox":"-64.297112,10.502084,-63.714592,10.795717",
     "geom:latitude":10.602977,
     "geom:longitude":-63.986381,
@@ -125,12 +125,13 @@
         "qs_pg:id":1314640,
         "wd:id":"Q2203040"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d8b01968db50c3adf784112b0f63c0a",
+    "wof:geomhash":"967b6a4ab216bd774ec6b174bf03c757",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421172601,
-    "wof:lastmodified":1690915069,
+    "wof:lastmodified":1695886193,
     "wof:name":"Cruz Salmeron Acosta",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/172/603/421172603.geojson
+++ b/data/421/172/603/421172603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041562,
-    "geom:area_square_m":507636602.828365,
+    "geom:area_square_m":507636303.974235,
     "geom:bbox":"-71.095053,8.810421,-70.869295,9.134568",
     "geom:latitude":8.974544,
     "geom:longitude":-70.96553,
@@ -130,12 +130,13 @@
         "qs_pg:id":1314642,
         "wd:id":"Q3088418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7acd537597da71d095bec5cba9f22127",
+    "wof:geomhash":"76abc85deca044844833831388c83fc3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421172603,
-    "wof:lastmodified":1690915065,
+    "wof:lastmodified":1695886193,
     "wof:name":"Justo Brice\u00f1o",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/172/605/421172605.geojson
+++ b/data/421/172/605/421172605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043678,
-    "geom:area_square_m":533243871.37289,
+    "geom:area_square_m":533243778.434709,
     "geom:bbox":"-70.730746,8.979711,-70.443266,9.291925",
     "geom:latitude":9.129878,
     "geom:longitude":-70.583589,
@@ -112,12 +112,13 @@
         "qs_pg:id":1314643,
         "wd:id":"Q403816"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008948,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75fcf21a2f29726740603d8636bd9de2",
+    "wof:geomhash":"a01ce1d75089c88bc00b9b9776c4dd6e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421172605,
-    "wof:lastmodified":1690915064,
+    "wof:lastmodified":1695886193,
     "wof:name":"Urdaneta",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/173/573/421173573.geojson
+++ b/data/421/173/573/421173573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055589,
-    "geom:area_square_m":679585815.142905,
+    "geom:area_square_m":679585923.448597,
     "geom:bbox":"-71.909424,8.500137,-71.51,8.769167",
     "geom:latitude":8.628347,
     "geom:longitude":-71.684258,
@@ -129,12 +129,13 @@
         "qs_pg:id":510638,
         "wd:id":"Q2124390"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459008990,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e0ae954052ad2eb83c8e92bf5c26cba",
+    "wof:geomhash":"e88473d4c6d16942b00c9626acc469a9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421173573,
-    "wof:lastmodified":1690915056,
+    "wof:lastmodified":1695886192,
     "wof:name":"Alberto Adriani",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/175/071/421175071.geojson
+++ b/data/421/175/071/421175071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068212,
-    "geom:area_square_m":832216915.590501,
+    "geom:area_square_m":832217148.763668,
     "geom:bbox":"-64.56735,9.047429,-64.349022,9.568826",
     "geom:latitude":9.363077,
     "geom:longitude":-64.466922,
@@ -290,12 +290,13 @@
         "qs_pg:id":919261,
         "wd:id":"Q943822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009054,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a1274bcabd7da8c44f3a99772f058ba",
+    "wof:geomhash":"92b3c6a73aee5c7e537cd1f0b15f22a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -305,7 +306,7 @@
         }
     ],
     "wof:id":421175071,
-    "wof:lastmodified":1690915086,
+    "wof:lastmodified":1695886196,
     "wof:name":"Anaco",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/175/381/421175381.geojson
+++ b/data/421/175/381/421175381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137045,
-    "geom:area_square_m":1677610193.64615,
+    "geom:area_square_m":1677610169.246442,
     "geom:bbox":"-71.632373,7.853307,-71.175,8.364317",
     "geom:latitude":8.116375,
     "geom:longitude":-71.40028,
@@ -127,12 +127,13 @@
         "qs_pg:id":368894,
         "wd:id":"Q2866132"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8541f8689345be24f765585131661926",
+    "wof:geomhash":"9442aab8344814ea6d77e0fd58b762c5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421175381,
-    "wof:lastmodified":1690915088,
+    "wof:lastmodified":1695886195,
     "wof:name":"Arzobispo Chacon",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/175/383/421175383.geojson
+++ b/data/421/175/383/421175383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.999983,
-    "geom:area_square_m":49192610979.068291,
+    "geom:area_square_m":49192610265.389702,
     "geom:bbox":"-65.278484,3.839789,-63.33274,8.098234",
     "geom:latitude":5.863071,
     "geom:longitude":-64.436749,
@@ -478,12 +478,13 @@
         "qs_pg:id":368895,
         "wd:id":"Q2907"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009065,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f667df57c6e515dd066b69ab02de72e",
+    "wof:geomhash":"48e73e9c7c59fb23e64b1c89c100e713",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -493,7 +494,7 @@
         }
     ],
     "wof:id":421175383,
-    "wof:lastmodified":1690915087,
+    "wof:lastmodified":1695886194,
     "wof:name":"Sucre",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/177/411/421177411.geojson
+++ b/data/421/177/411/421177411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004709,
-    "geom:area_square_m":57267508.645159,
+    "geom:area_square_m":57267545.293435,
     "geom:bbox":"-66.998602,10.351283,-66.8925,10.423169",
     "geom:latitude":10.388725,
     "geom:longitude":-66.944848,
@@ -142,12 +142,13 @@
         "qs_pg:id":421476,
         "wd:id":"Q827414"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009143,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4700f640be3443fa35ef7e03f61e20fc",
+    "wof:geomhash":"1e7b795c547639a895f2e02f8e58f5ef",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421177411,
-    "wof:lastmodified":1690915108,
+    "wof:lastmodified":1695886198,
     "wof:name":"Los Salias",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/177/413/421177413.geojson
+++ b/data/421/177/413/421177413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004807,
-    "geom:area_square_m":58387614.221511,
+    "geom:area_square_m":58387553.758813,
     "geom:bbox":"-64.005447,10.732056,-63.892056,10.81375",
     "geom:latitude":10.772301,
     "geom:longitude":-63.943878,
@@ -190,12 +190,13 @@
         "qs_pg:id":421479,
         "wd:id":"Q2208173"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009143,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1736d499123cf78dd01a667e7b76f444",
+    "wof:geomhash":"c5edb25cf8cc3402cc3fd0e2962b3325",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":421177413,
-    "wof:lastmodified":1690915107,
+    "wof:lastmodified":1695886198,
     "wof:name":"Villalba",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/180/477/421180477.geojson
+++ b/data/421/180/477/421180477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009107,
-    "geom:area_square_m":110806779.554965,
+    "geom:area_square_m":110806829.400461,
     "geom:bbox":"-67.990846,10.187079,-67.909876,10.360044",
     "geom:latitude":10.268389,
     "geom:longitude":-67.950257,
@@ -531,12 +531,13 @@
         "qs_pg:id":504822,
         "wd:id":"Q16552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009260,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ab311d58e719222cd0218d493faa709",
+    "wof:geomhash":"d5d1dc198eedfea4eb0c082d9bd1cc77",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -546,7 +547,7 @@
         }
     ],
     "wof:id":421180477,
-    "wof:lastmodified":1690915052,
+    "wof:lastmodified":1695886190,
     "wof:name":"San Diego",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/180/891/421180891.geojson
+++ b/data/421/180/891/421180891.geojson
@@ -351,6 +351,7 @@
         "hasc:id":"VE.FA.FA",
         "qs_pg:id":467180
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009274,
     "wof:geom_alt":[
@@ -366,7 +367,7 @@
         }
     ],
     "wof:id":421180891,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886191,
     "wof:name":"Falcon",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/180/895/421180895.geojson
+++ b/data/421/180/895/421180895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226154,
-    "geom:area_square_m":2752486753.518064,
+    "geom:area_square_m":2752486379.831747,
     "geom:bbox":"-69.66852,9.729628,-69.14,10.525007",
     "geom:latitude":10.170467,
     "geom:longitude":-69.417757,
@@ -155,12 +155,13 @@
         "qs_pg:id":467182,
         "wd:id":"Q2435584"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009274,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9edbf7e7d0e2521db763e52cbb036a2c",
+    "wof:geomhash":"a267394b1d2a28191f9c6e87f34eb0a7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421180895,
-    "wof:lastmodified":1690915053,
+    "wof:lastmodified":1695886191,
     "wof:name":"Iribarren",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/180/897/421180897.geojson
+++ b/data/421/180/897/421180897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047407,
-    "geom:area_square_m":574766068.399535,
+    "geom:area_square_m":574765508.661516,
     "geom:bbox":"-69.629434,11.124259,-69.375508,11.511222",
     "geom:latitude":11.330519,
     "geom:longitude":-69.479195,
@@ -145,12 +145,13 @@
         "qs_pg:id":467183,
         "wd:id":"Q2408734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009275,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e83adddb7d89fc2eefa0ce81db98662a",
+    "wof:geomhash":"f6c9fc8386760b4dfc74af46aa1f7161",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":421180897,
-    "wof:lastmodified":1690915054,
+    "wof:lastmodified":1695886192,
     "wof:name":"Colina",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/180/899/421180899.geojson
+++ b/data/421/180/899/421180899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.977258,
-    "geom:area_square_m":11998098600.326477,
+    "geom:area_square_m":11998097293.239641,
     "geom:bbox":"-70.338059,6.246446,-68.6,7.350695",
     "geom:latitude":6.831009,
     "geom:longitude":-69.43256,
@@ -226,12 +226,13 @@
         "qs_pg:id":467191,
         "wd:id":"Q311401"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009275,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1b3975ac95fff7f763f2575fe9742b7",
+    "wof:geomhash":"c2cf893f4af6f6c837ad8d5208a454b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -241,7 +242,7 @@
         }
     ],
     "wof:id":421180899,
-    "wof:lastmodified":1690915053,
+    "wof:lastmodified":1695886192,
     "wof:name":"Romulo Gallegos",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/181/777/421181777.geojson
+++ b/data/421/181/777/421181777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014917,
-    "geom:area_square_m":181494860.729824,
+    "geom:area_square_m":181495244.890986,
     "geom:bbox":"-67.293342,10.171477,-67.188333,10.357147",
     "geom:latitude":10.262861,
     "geom:longitude":-67.240268,
@@ -107,12 +107,13 @@
         "qs_pg:id":510536,
         "wd:id":"Q6293778"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009306,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b9ff586a78d5e04ae54fa700479632d",
+    "wof:geomhash":"cacc153c253a26acaf8f5da4e460ea9e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421181777,
-    "wof:lastmodified":1690915083,
+    "wof:lastmodified":1695886194,
     "wof:name":"Jose Rafael Revenga",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/181/779/421181779.geojson
+++ b/data/421/181/779/421181779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01664,
-    "geom:area_square_m":202674853.612065,
+    "geom:area_square_m":202674892.794675,
     "geom:bbox":"-65.117149,9.809038,-64.96897,10.059757",
     "geom:latitude":9.928895,
     "geom:longitude":-65.046572,
@@ -136,12 +136,13 @@
         "qs_pg:id":510537,
         "wd:id":"Q965270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009306,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cef245a07723ec9325740776f2dc9dc6",
+    "wof:geomhash":"0526a32a4060bca082b4aea33602898c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421181779,
-    "wof:lastmodified":1690915083,
+    "wof:lastmodified":1695886194,
     "wof:name":"Piritu",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/181/907/421181907.geojson
+++ b/data/421/181/907/421181907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066414,
-    "geom:area_square_m":811413085.495052,
+    "geom:area_square_m":811412923.777403,
     "geom:bbox":"-70.41277,8.713011,-70.043531,9.061229",
     "geom:latitude":8.864591,
     "geom:longitude":-70.248506,
@@ -123,12 +123,13 @@
         "qs_pg:id":510639,
         "wd:id":"Q2046275"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddedc43ca9c3fa26eb4e3f6bae323070",
+    "wof:geomhash":"383d43f107f44911365bd8a9251b97a7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421181907,
-    "wof:lastmodified":1690915081,
+    "wof:lastmodified":1695886194,
     "wof:name":"Cruz Paredes",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/182/049/421182049.geojson
+++ b/data/421/182/049/421182049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014954,
-    "geom:area_square_m":182485626.338216,
+    "geom:area_square_m":182485345.901721,
     "geom:bbox":"-70.814351,9.197197,-70.625956,9.373623",
     "geom:latitude":9.275538,
     "geom:longitude":-70.715809,
@@ -120,12 +120,13 @@
         "qs_pg:id":576984,
         "wd:id":"Q2254362"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009317,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a153eb6f864c94dffbe2049c0e9f07d",
+    "wof:geomhash":"5396a5ed096239646632ad15ca53d1bf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182049,
-    "wof:lastmodified":1690915113,
+    "wof:lastmodified":1695886199,
     "wof:name":"Escuque",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/182/143/421182143.geojson
+++ b/data/421/182/143/421182143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017004,
-    "geom:area_square_m":206874518.483586,
+    "geom:area_square_m":206874591.788804,
     "geom:bbox":"-68.154736,10.229509,-67.969442,10.345736",
     "geom:latitude":10.285038,
     "geom:longitude":-68.062817,
@@ -169,12 +169,13 @@
         "wd:id":"Q2255048",
         "wk:page":"Naguanagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009320,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86f748b3c1936842136baa9a8c35355f",
+    "wof:geomhash":"ccdb975bdf8edb0c821eb8d57316ba49",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":421182143,
-    "wof:lastmodified":1690915114,
+    "wof:lastmodified":1695886199,
     "wof:name":"Naguanagua",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/182/997/421182997.geojson
+++ b/data/421/182/997/421182997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084416,
-    "geom:area_square_m":1031629728.553142,
+    "geom:area_square_m":1031629754.580638,
     "geom:bbox":"-64.20078,8.573792,-63.61,8.930427",
     "geom:latitude":8.762782,
     "geom:longitude":-63.910817,
@@ -148,7 +148,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dda66a80fd6a92b2b6cbcac4fb678895",
+    "wof:geomhash":"8a9f8979a1c52d29f498d1f7fdeae77d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +158,7 @@
         }
     ],
     "wof:id":421182997,
-    "wof:lastmodified":1690915113,
+    "wof:lastmodified":1695886199,
     "wof:name":"Guanipa",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/183/169/421183169.geojson
+++ b/data/421/183/169/421183169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054085,
-    "geom:area_square_m":659233060.09115,
+    "geom:area_square_m":659233533.899118,
     "geom:bbox":"-69.72789,9.558156,-69.345745,9.814533",
     "geom:latitude":9.690285,
     "geom:longitude":-69.563909,
@@ -163,12 +163,13 @@
         "qs_pg:id":966263,
         "wd:id":"Q4760185"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009360,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"44e89afb4d2c3321149187080713a8e0",
+    "wof:geomhash":"63324ab543aa38968a7e5f27095b8a33",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421183169,
-    "wof:lastmodified":1690915109,
+    "wof:lastmodified":1695886199,
     "wof:name":"Andres Eloy Blanco",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/183/171/421183171.geojson
+++ b/data/421/183/171/421183171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119218,
-    "geom:area_square_m":1460134071.219114,
+    "geom:area_square_m":1460134189.919223,
     "geom:bbox":"-71.991245,7.63237,-71.505249,8.180036",
     "geom:latitude":7.908588,
     "geom:longitude":-71.751125,
@@ -120,12 +120,13 @@
         "qs_pg:id":966265,
         "wd:id":"Q3072187"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009360,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bde56a2a3d5bb9b0a609c26e2cafc16e",
+    "wof:geomhash":"8dc610d4413b33693a3c7d5a863506fe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421183171,
-    "wof:lastmodified":1690915112,
+    "wof:lastmodified":1695886199,
     "wof:name":"Uribante",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/183/211/421183211.geojson
+++ b/data/421/183/211/421183211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041232,
-    "geom:area_square_m":504245329.494434,
+    "geom:area_square_m":504245354.298347,
     "geom:bbox":"-71.983249,8.348931,-71.772065,8.643743",
     "geom:latitude":8.499602,
     "geom:longitude":-71.881567,
@@ -89,12 +89,13 @@
         "hasc:id":"VE.TA.SM",
         "qs_pg:id":968977
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009362,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d39e52424c0ba4708fea9150f9ddd816",
+    "wof:geomhash":"e3c653a452b4deceb261d98b0cc818a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421183211,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886181,
     "wof:name":"Samuel Dario Maldonado",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/183/227/421183227.geojson
+++ b/data/421/183/227/421183227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.64992,
-    "geom:area_square_m":7930596870.478348,
+    "geom:area_square_m":7930597335.769654,
     "geom:bbox":"-64.479058,8.759927,-63.37,10.121882",
     "geom:latitude":9.301457,
     "geom:longitude":-64.030469,
@@ -152,7 +152,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bffdef6e5cfb5427cae84eefe4be0e2",
+    "wof:geomhash":"169e2027d239daa086c55dc401a0843a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +162,7 @@
         }
     ],
     "wof:id":421183227,
-    "wof:lastmodified":1690915109,
+    "wof:lastmodified":1695886199,
     "wof:name":"Freites",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/183/445/421183445.geojson
+++ b/data/421/183/445/421183445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223971,
-    "geom:area_square_m":2739084366.533978,
+    "geom:area_square_m":2739084386.154105,
     "geom:bbox":"-62.606779,8.28723,-61.614697,8.721324",
     "geom:latitude":8.491469,
     "geom:longitude":-62.109644,
@@ -90,12 +90,13 @@
         "hasc:id":"VE.DA.CA",
         "qs_pg:id":977701
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009369,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"833b91c814ec2fa8b5ec40cb049579fd",
+    "wof:geomhash":"2a05c632f0680ff7ec0c39bbcedd6506",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421183445,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886180,
     "wof:name":"Casacoima",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/421/184/195/421184195.geojson
+++ b/data/421/184/195/421184195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425816,
-    "geom:area_square_m":5207714941.310831,
+    "geom:area_square_m":5207714701.689072,
     "geom:bbox":"-64.84,7.946511,-63.85125,8.950143",
     "geom:latitude":8.477801,
     "geom:longitude":-64.289797,
@@ -268,12 +268,13 @@
         "qs_pg:id":990182,
         "wd:id":"Q106884"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009403,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02397554d9e32372e9dd2b51e3356911",
+    "wof:geomhash":"a2bd6f39eb71e583767e47481d1bfa4f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -283,7 +284,7 @@
         }
     ],
     "wof:id":421184195,
-    "wof:lastmodified":1690915103,
+    "wof:lastmodified":1695886197,
     "wof:name":"Miranda",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/184/293/421184293.geojson
+++ b/data/421/184/293/421184293.geojson
@@ -188,6 +188,7 @@
         "hasc:id":"VE.AR.ZA",
         "qs_pg:id":993184
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009406,
     "wof:geom_alt":[
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":421184293,
-    "wof:lastmodified":1694492945,
+    "wof:lastmodified":1695886197,
     "wof:name":"Zamora",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/184/351/421184351.geojson
+++ b/data/421/184/351/421184351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033597,
-    "geom:area_square_m":410783965.625186,
+    "geom:area_square_m":410784161.319084,
     "geom:bbox":"-71.107449,8.419522,-70.831702,8.74",
     "geom:latitude":8.576182,
     "geom:longitude":-70.954459,
@@ -108,12 +108,13 @@
         "qs_pg:id":995554,
         "wd:id":"Q929490"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009408,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"99cf79ae82d3242296d239c047927bbe",
+    "wof:geomhash":"f43fd52e2174f616d26e949beb4b8bf6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421184351,
-    "wof:lastmodified":1690915105,
+    "wof:lastmodified":1695886198,
     "wof:name":"Santos Marquina",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/184/387/421184387.geojson
+++ b/data/421/184/387/421184387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084238,
-    "geom:area_square_m":1025513561.348868,
+    "geom:area_square_m":1025513394.833185,
     "geom:bbox":"-65.888573,9.948518,-65.431009,10.222961",
     "geom:latitude":10.0882,
     "geom:longitude":-65.692552,
@@ -130,12 +130,13 @@
         "qs_pg:id":995752,
         "wd:id":"Q2388590"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009409,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09922e39870315f4cd2b551d75e6864c",
+    "wof:geomhash":"ceb18bc46475d47c5860450f88c02e38",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421184387,
-    "wof:lastmodified":1690915105,
+    "wof:lastmodified":1695886198,
     "wof:name":"Pedro Gual",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/184/557/421184557.geojson
+++ b/data/421/184/557/421184557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032274,
-    "geom:area_square_m":392761635.5091,
+    "geom:area_square_m":392760906.345994,
     "geom:bbox":"-67.434664,10.08791,-67.198702,10.35023",
     "geom:latitude":10.203843,
     "geom:longitude":-67.316736,
@@ -121,12 +121,13 @@
         "qs_pg:id":1001535,
         "wd:id":"Q3624022"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009414,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9e0c4f7a0ad71a06098003668e8e4a1",
+    "wof:geomhash":"0e35a4f28b29b96b592b337710cf6ebe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421184557,
-    "wof:lastmodified":1690915103,
+    "wof:lastmodified":1695886198,
     "wof:name":"Jose Felix Ribas",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/185/095/421185095.geojson
+++ b/data/421/185/095/421185095.geojson
@@ -81,6 +81,7 @@
         "hasc:id":"VE.AR.BO",
         "qs_pg:id":1018465
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009432,
     "wof:geom_alt":[
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":421185095,
-    "wof:lastmodified":1694492945,
+    "wof:lastmodified":1695886197,
     "wof:name":"Bolivar",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/185/127/421185127.geojson
+++ b/data/421/185/127/421185127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069968,
-    "geom:area_square_m":848775189.989411,
+    "geom:area_square_m":848775189.989307,
     "geom:bbox":"-68.77,10.976041473,-68.3376633772,11.359582901",
     "geom:latitude":11.17226,
     "geom:longitude":-68.555059,
@@ -139,12 +139,13 @@
         "qs_pg:id":1018464,
         "wd:id":"Q2745788"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009433,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae44b8af73db6809ea1dbbbc3106149c",
+    "wof:geomhash":"4940990eb93b7a8f09f252afee51314d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421185127,
-    "wof:lastmodified":1582393027,
+    "wof:lastmodified":1695886200,
     "wof:name":"Acosta",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/185/263/421185263.geojson
+++ b/data/421/185/263/421185263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034159,
-    "geom:area_square_m":415891956.286916,
+    "geom:area_square_m":415891635.017708,
     "geom:bbox":"-69.208959,9.877453,-69.008333,10.232073",
     "geom:latitude":10.053867,
     "geom:longitude":-69.105337,
@@ -319,12 +319,13 @@
         "qs_pg:id":1020138,
         "wd:id":"Q1683068"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009437,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6cb55f6611ec195df15a3cb8a05ce4de",
+    "wof:geomhash":"ae12ebc40783c3c96d577edeb8979337",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -334,7 +335,7 @@
         }
     ],
     "wof:id":421185263,
-    "wof:lastmodified":1690915126,
+    "wof:lastmodified":1695886200,
     "wof:name":"Pe\u00f1a",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/185/265/421185265.geojson
+++ b/data/421/185/265/421185265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049144,
-    "geom:area_square_m":602419182.438753,
+    "geom:area_square_m":602418827.170454,
     "geom:bbox":"-72.385592,7.420256,-72.067034,7.69619",
     "geom:latitude":7.541449,
     "geom:longitude":-72.235925,
@@ -154,12 +154,13 @@
         "qs_pg:id":1020139,
         "wd:id":"Q2664224"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009437,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b782e68405a19b3e808a73550f089b6",
+    "wof:geomhash":"17a4440cda620de4177ffbd45cc022cf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":421185265,
-    "wof:lastmodified":1690915125,
+    "wof:lastmodified":1695886197,
     "wof:name":"Cordova",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/186/159/421186159.geojson
+++ b/data/421/186/159/421186159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032905,
-    "geom:area_square_m":402186564.670727,
+    "geom:area_square_m":402186660.871128,
     "geom:bbox":"-71.543672,8.617408,-71.213179,8.795869",
     "geom:latitude":8.710009,
     "geom:longitude":-71.395154,
@@ -194,12 +194,13 @@
         "qs_pg:id":912044,
         "wd:id":"Q439195"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009472,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57ff790d8187b1ce42931af0b768feec",
+    "wof:geomhash":"e70a3a3e506e4419b4818d34057b6294",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":421186159,
-    "wof:lastmodified":1690915070,
+    "wof:lastmodified":1695886194,
     "wof:name":"Andres Bello",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/186/263/421186263.geojson
+++ b/data/421/186/263/421186263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041829,
-    "geom:area_square_m":508766009.4338,
+    "geom:area_square_m":508765945.859959,
     "geom:bbox":"-67.572609,10.188619,-67.396539,10.540389",
     "geom:latitude":10.373812,
     "geom:longitude":-67.487625,
@@ -193,12 +193,13 @@
         "qs_pg:id":1063001,
         "wd:id":"Q2226100"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009475,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"864150848c2047d3d8e19a082eec47ab",
+    "wof:geomhash":"6c361ce744a73f85887f61766298d72e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":421186263,
-    "wof:lastmodified":1690915078,
+    "wof:lastmodified":1695886194,
     "wof:name":"Santiago Mari\u00f1o",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/186/265/421186265.geojson
+++ b/data/421/186/265/421186265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05298,
-    "geom:area_square_m":644789699.444355,
+    "geom:area_square_m":644789883.929551,
     "geom:bbox":"-63.617817,10.069807,-63.196428,10.320608",
     "geom:latitude":10.181595,
     "geom:longitude":-63.411006,
@@ -147,12 +147,13 @@
         "qs_pg:id":1063002,
         "wd:id":"Q2938835"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009475,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"098f35b1d4a771a40d46372386310a80",
+    "wof:geomhash":"90e965e5cac67562bc3a83638787f48d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421186265,
-    "wof:lastmodified":1690915078,
+    "wof:lastmodified":1695886195,
     "wof:name":"Caripe",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/421/186/375/421186375.geojson
+++ b/data/421/186/375/421186375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.053798,
-    "geom:area_square_m":12851893613.553352,
+    "geom:area_square_m":12851893769.37657,
     "geom:bbox":"-63.533777,8.747505,-62.291346,10.237917",
     "geom:latitude":9.489287,
     "geom:longitude":-62.923814,
@@ -157,12 +157,13 @@
         "qs_pg:id":1064937,
         "wd:id":"Q3300002"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009479,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5cab6ade9eec23a5f28253b8122a546d",
+    "wof:geomhash":"683dd06d1afb5d3c6dd3e042b1c6bb2d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421186375,
-    "wof:lastmodified":1690915079,
+    "wof:lastmodified":1695886195,
     "wof:name":"Maturin",
     "wof:parent_id":85680547,
     "wof:placetype":"county",

--- a/data/421/186/435/421186435.geojson
+++ b/data/421/186/435/421186435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230958,
-    "geom:area_square_m":2821490883.786295,
+    "geom:area_square_m":2821491025.84778,
     "geom:bbox":"-72.187261,8.583512,-71.644056,9.239861",
     "geom:latitude":8.89497,
     "geom:longitude":-71.911816,
@@ -122,12 +122,13 @@
         "qs_pg:id":1068889,
         "wd:id":"Q2271833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009481,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"882df7128cc45e6f6288e2a79788b533",
+    "wof:geomhash":"2e511085e9e06a1d747f0f9f92afad0a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421186435,
-    "wof:lastmodified":1690915078,
+    "wof:lastmodified":1695886195,
     "wof:name":"Colon",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/188/083/421188083.geojson
+++ b/data/421/188/083/421188083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.131577,
-    "geom:area_square_m":1605949635.953843,
+    "geom:area_square_m":1605949693.852823,
     "geom:bbox":"-70.551604,8.961172,-70.040593,9.523595",
     "geom:latitude":9.220193,
     "geom:longitude":-70.260414,
@@ -131,12 +131,13 @@
         "wd:id":"Q889344",
         "wk:page":"Bocon\u00f3"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009533,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"137d02d03ac7ce0d66826bca8f4ef3de",
+    "wof:geomhash":"c762e8a7c251da7fa96993722aebeb0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421188083,
-    "wof:lastmodified":1690915062,
+    "wof:lastmodified":1695886193,
     "wof:name":"Bocono",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/188/591/421188591.geojson
+++ b/data/421/188/591/421188591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018009,
-    "geom:area_square_m":219074083.969785,
+    "geom:area_square_m":219074157.980561,
     "geom:bbox":"-66.227217,10.249566,-66.017771,10.406395",
     "geom:latitude":10.336904,
     "geom:longitude":-66.112064,
@@ -133,12 +133,13 @@
         "qs_pg:id":1104448,
         "wd:id":"Q751150"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009570,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8e372981f4fa87f87b6939bd1d6a3e2",
+    "wof:geomhash":"a10f625c3284e17c3d4afe3cd6b8230a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421188591,
-    "wof:lastmodified":1690915064,
+    "wof:lastmodified":1695886193,
     "wof:name":"Buroz",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/188/829/421188829.geojson
+++ b/data/421/188/829/421188829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040862,
-    "geom:area_square_m":498581232.975869,
+    "geom:area_square_m":498581439.567126,
     "geom:bbox":"-70.563276,9.180288,-70.294125,9.449655",
     "geom:latitude":9.326951,
     "geom:longitude":-70.425116,
@@ -358,12 +358,13 @@
         "qs_pg:id":1104425,
         "wd:id":"Q2527815"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009581,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9e18e5268b04d9aaaa7b291a65f2a50",
+    "wof:geomhash":"5c53c51e540c103d7f30481589b3131a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -373,7 +374,7 @@
         }
     ],
     "wof:id":421188829,
-    "wof:lastmodified":1690915061,
+    "wof:lastmodified":1695886196,
     "wof:name":"Trujillo",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/421/188/833/421188833.geojson
+++ b/data/421/188/833/421188833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016645,
-    "geom:area_square_m":202527996.303102,
+    "geom:area_square_m":202527979.69532,
     "geom:bbox":"-67.850651,10.173745,-67.724394,10.351638",
     "geom:latitude":10.264159,
     "geom:longitude":-67.785623,
@@ -201,12 +201,13 @@
         "qs_pg:id":1104442,
         "wd:id":"Q1631420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009581,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52cb15aa9e99ced1a3501b635fde8468",
+    "wof:geomhash":"12411fa20681333de97e2d4293a36992",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":421188833,
-    "wof:lastmodified":1690915063,
+    "wof:lastmodified":1695886196,
     "wof:name":"San Joaquin",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/188/835/421188835.geojson
+++ b/data/421/188/835/421188835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039235,
-    "geom:area_square_m":477167661.950941,
+    "geom:area_square_m":477167488.031671,
     "geom:bbox":"-67.88,10.27007,-67.597674,10.509556",
     "geom:latitude":10.407996,
     "geom:longitude":-67.738316,
@@ -125,12 +125,13 @@
         "qs_pg:id":1104443,
         "wd:id":"Q9291717"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009581,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8bd4eda0ff38a9dd32b12e97fb75913",
+    "wof:geomhash":"c2b53c77efdd6baf62d86c68da79182c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421188835,
-    "wof:lastmodified":1690915062,
+    "wof:lastmodified":1695886193,
     "wof:name":"Mario Brice\u00f1o Iragorri",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/189/069/421189069.geojson
+++ b/data/421/189/069/421189069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053716,
-    "geom:area_square_m":656417444.12519,
+    "geom:area_square_m":656417599.244866,
     "geom:bbox":"-64.354882,8.586587,-63.992324,8.950972",
     "geom:latitude":8.781938,
     "geom:longitude":-64.178697,
@@ -180,12 +180,13 @@
         "qs_pg:id":1110084,
         "wd:id":"Q2404225"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009603,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d389f57ead044d24bafdd84656fa77e",
+    "wof:geomhash":"501ce076bd8fa904875df1d923dbf7d3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":421189069,
-    "wof:lastmodified":1690915061,
+    "wof:lastmodified":1695886193,
     "wof:name":"Simon Rodriguez",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/189/073/421189073.geojson
+++ b/data/421/189/073/421189073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070499,
-    "geom:area_square_m":858668096.079585,
+    "geom:area_square_m":858668148.264071,
     "geom:bbox":"-69.759691,9.722704,-69.4726,10.155637",
     "geom:latitude":9.933275,
     "geom:longitude":-69.612915,
@@ -171,12 +171,13 @@
         "qs_pg:id":1110091,
         "wd:id":"Q952348"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009603,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ca4c35de8c9316951fd22eeb3ae85ff",
+    "wof:geomhash":"711ec17bf9cb4a8943ed7ee06c00862c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421189073,
-    "wof:lastmodified":1690915059,
+    "wof:lastmodified":1695886192,
     "wof:name":"Jimenez",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/189/075/421189075.geojson
+++ b/data/421/189/075/421189075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082403,
-    "geom:area_square_m":1003402329.832847,
+    "geom:area_square_m":1003402010.552089,
     "geom:bbox":"-67.979066,9.828655,-67.518118,10.19632",
     "geom:latitude":10.014975,
     "geom:longitude":-67.738914,
@@ -158,12 +158,13 @@
         "qs_pg:id":1110092,
         "wd:id":"Q1042713"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009604,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fdf34a2f3332c75ebda29e956a881717",
+    "wof:geomhash":"761f45e7068ea738efd79736ec89c604",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421189075,
-    "wof:lastmodified":1690915060,
+    "wof:lastmodified":1695886194,
     "wof:name":"Carlos Arvelo",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/189/079/421189079.geojson
+++ b/data/421/189/079/421189079.geojson
@@ -94,7 +94,7 @@
         }
     ],
     "wof:id":421189079,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886192,
     "wof:name":"Mellado",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/421/189/081/421189081.geojson
+++ b/data/421/189/081/421189081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015857,
-    "geom:area_square_m":192808044.88211,
+    "geom:area_square_m":192808293.054657,
     "geom:bbox":"-66.720408,10.408999,-66.578677,10.548768",
     "geom:latitude":10.477928,
     "geom:longitude":-66.651149,
@@ -148,12 +148,13 @@
         "qs_pg:id":1110095,
         "wd:id":"Q1149242"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009604,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc6ba93b4db205439c506b545536404c",
+    "wof:geomhash":"3a074aac46c23a174022a1a7a72d8e1d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":421189081,
-    "wof:lastmodified":1690915060,
+    "wof:lastmodified":1695886192,
     "wof:name":"Plaza",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/189/087/421189087.geojson
+++ b/data/421/189/087/421189087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190232,
-    "geom:area_square_m":2322365438.828749,
+    "geom:area_square_m":2322365247.578234,
     "geom:bbox":"-69.994462,8.869275,-69.435237,9.440633",
     "geom:latitude":9.142379,
     "geom:longitude":-69.727378,
@@ -183,12 +183,13 @@
         "qs_pg:id":1110107,
         "wd:id":"Q3118730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009604,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f792c7e2d1ade41c0f4284fe4c08d1eb",
+    "wof:geomhash":"1d8666fce9330ff0c14fd288348a2720",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -198,7 +199,7 @@
         }
     ],
     "wof:id":421189087,
-    "wof:lastmodified":1690915059,
+    "wof:lastmodified":1695886196,
     "wof:name":"Guanare",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/421/189/269/421189269.geojson
+++ b/data/421/189/269/421189269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038454,
-    "geom:area_square_m":470721577.060144,
+    "geom:area_square_m":470721441.237925,
     "geom:bbox":"-72.393309,7.9861,-72.159277,8.313085",
     "geom:latitude":8.118378,
     "geom:longitude":-72.284946,
@@ -123,12 +123,13 @@
         "qs_pg:id":421480,
         "wd:id":"Q2874853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009615,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c233d457ee4976db9b86fb898ce1f20",
+    "wof:geomhash":"62161b62c20ec2e596670382bcc1867a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421189269,
-    "wof:lastmodified":1690915058,
+    "wof:lastmodified":1695886196,
     "wof:name":"Ayacucho",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/190/213/421190213.geojson
+++ b/data/421/190/213/421190213.geojson
@@ -556,6 +556,7 @@
         "hasc:id":"VE.FA.SF",
         "qs_pg:id":1118977
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009650,
     "wof:geom_alt":[
@@ -571,7 +572,7 @@
         }
     ],
     "wof:id":421190213,
-    "wof:lastmodified":1694492945,
+    "wof:lastmodified":1695886196,
     "wof:name":"San Francisco",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/190/215/421190215.geojson
+++ b/data/421/190/215/421190215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173865,
-    "geom:area_square_m":2118416633.993644,
+    "geom:area_square_m":2118416545.730224,
     "geom:bbox":"-64.8725,9.55801,-64.11,10.086631",
     "geom:latitude":9.812453,
     "geom:longitude":-64.486692,
@@ -189,12 +189,13 @@
         "qs_pg:id":1118978,
         "wd:id":"Q2530307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009650,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"661d9dc1eaa3338b7fbf1b9f92cd5636",
+    "wof:geomhash":"6a587c3dc0229ace5e79f88c259e9d2e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -204,7 +205,7 @@
         }
     ],
     "wof:id":421190215,
-    "wof:lastmodified":1690915096,
+    "wof:lastmodified":1695886197,
     "wof:name":"Libertad",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/190/237/421190237.geojson
+++ b/data/421/190/237/421190237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126517,
-    "geom:area_square_m":1548290300.137053,
+    "geom:area_square_m":1548289984.918699,
     "geom:bbox":"-63.020188,7.979029,-62.4975,8.447935",
     "geom:latitude":8.231103,
     "geom:longitude":-62.752585,
@@ -160,12 +160,13 @@
         "qs_pg:id":1119098,
         "wd:id":"Q2354199"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009651,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d56cf6c4a6231e3d57246ade37931ac0",
+    "wof:geomhash":"b93f26ab95fa900a33343c9ffe8c787b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421190237,
-    "wof:lastmodified":1690915096,
+    "wof:lastmodified":1695886197,
     "wof:name":"Caroni",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/190/239/421190239.geojson
+++ b/data/421/190/239/421190239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059807,
-    "geom:area_square_m":730958851.000144,
+    "geom:area_square_m":730958642.605459,
     "geom:bbox":"-71.035172,8.584243,-70.708999,8.89111",
     "geom:latitude":8.72635,
     "geom:longitude":-70.873403,
@@ -109,12 +109,13 @@
         "qs_pg:id":1119105,
         "wd:id":"Q929490"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009651,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f794c34380bfce9b3e715e9a7e342301",
+    "wof:geomhash":"584db51c0b9c9335bfec1f20e031ccfd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421190239,
-    "wof:lastmodified":1690915096,
+    "wof:lastmodified":1695886197,
     "wof:name":"Rangel",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/190/785/421190785.geojson
+++ b/data/421/190/785/421190785.geojson
@@ -78,6 +78,7 @@
         "hasc:id":"VE.AP.PA",
         "qs_pg:id":1120993
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009669,
     "wof:geom_alt":[
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":421190785,
-    "wof:lastmodified":1694492874,
+    "wof:lastmodified":1695886372,
     "wof:name":"Paez",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/191/753/421191753.geojson
+++ b/data/421/191/753/421191753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.929014,
-    "geom:area_square_m":11337994497.485508,
+    "geom:area_square_m":11337994989.481504,
     "geom:bbox":"-62.406939,8.597735,-60.965443,9.904555",
     "geom:latitude":9.247536,
     "geom:longitude":-61.675693,
@@ -142,12 +142,13 @@
         "qs_pg:id":1154665,
         "wd:id":"Q2092931"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009706,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1019c772a2c2285b346b3a5a25792d8e",
+    "wof:geomhash":"ea29242e08cf6f259469f630cdc13391",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421191753,
-    "wof:lastmodified":1690915094,
+    "wof:lastmodified":1695886196,
     "wof:name":"Tucupita",
     "wof:parent_id":85680565,
     "wof:placetype":"county",

--- a/data/421/191/761/421191761.geojson
+++ b/data/421/191/761/421191761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025995,
-    "geom:area_square_m":317625229.61009,
+    "geom:area_square_m":317625229.610124,
     "geom:bbox":"-71.5925311597,8.71408169954,-71.305,8.94237204731",
     "geom:latitude":8.823626,
     "geom:longitude":-71.440566,
@@ -123,12 +123,13 @@
         "qs_pg:id":114644,
         "wd:id":"Q3055381"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009707,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4284757daf3a485d9f3630b9fb94ebf",
+    "wof:geomhash":"7d9a4560529a69dc2dfa3ab0d821afba",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421191761,
-    "wof:lastmodified":1582393023,
+    "wof:lastmodified":1695886196,
     "wof:name":"Obispo Ramos De Lora",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/193/365/421193365.geojson
+++ b/data/421/193/365/421193365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054629,
-    "geom:area_square_m":663768887.560627,
+    "geom:area_square_m":663768700.976412,
     "geom:bbox":"-63.204584,10.601213,-61.912356,11.395",
     "geom:latitude":10.693695,
     "geom:longitude":-62.803812,
@@ -103,12 +103,13 @@
         "qs_pg:id":891806,
         "wd:id":"Q418835"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009768,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bff026d487bca012662e393023716356",
+    "wof:geomhash":"e81397ad9448175bfd90e1c7079b0fc1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421193365,
-    "wof:lastmodified":1690915035,
+    "wof:lastmodified":1695886189,
     "wof:name":"Arismendi",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/193/381/421193381.geojson
+++ b/data/421/193/381/421193381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07952,
-    "geom:area_square_m":965694425.101419,
+    "geom:area_square_m":965694541.091689,
     "geom:bbox":"-68.94,10.64525,-68.217918,11.061664",
     "geom:latitude":10.85267,
     "geom:longitude":-68.59372,
@@ -90,12 +90,13 @@
         "hasc:id":"VE.FA.MI",
         "qs_pg:id":893636
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009769,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc6ac99dbd0cb5cc80cfcef4c9d6a226",
+    "wof:geomhash":"69c576857a559ae00a8911cd75142c57",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421193381,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886180,
     "wof:name":"Monse\u00f1or Iturriza",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/193/517/421193517.geojson
+++ b/data/421/193/517/421193517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007799,
-    "geom:area_square_m":94504238.883866,
+    "geom:area_square_m":94504107.719297,
     "geom:bbox":"-69.301614,11.441982,-69.160665,11.539583",
     "geom:latitude":11.49339,
     "geom:longitude":-69.231121,
@@ -105,12 +105,13 @@
         "hasc:id":"VE.FA.TO",
         "qs_pg:id":911165
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009774,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f7d29fee508ca15416068cfedf36d2cc",
+    "wof:geomhash":"cbe17f265ec1b823c612622654738368",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":421193517,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886182,
     "wof:name":"Tocopero",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/421/193/519/421193519.geojson
+++ b/data/421/193/519/421193519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075346,
-    "geom:area_square_m":917995016.887881,
+    "geom:area_square_m":917995139.990766,
     "geom:bbox":"-67.112421,9.67,-66.692673,9.986698",
     "geom:latitude":9.829086,
     "geom:longitude":-66.877969,
@@ -164,12 +164,13 @@
         "qs_pg:id":911166,
         "wd:id":"Q2011270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009774,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92f9128ce6974f07e790b95e7ecb7f84",
+    "wof:geomhash":"dcbeda643951e074cc1a1c62da858d2f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421193519,
-    "wof:lastmodified":1690915036,
+    "wof:lastmodified":1695886189,
     "wof:name":"Camatagua",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/194/073/421194073.geojson
+++ b/data/421/194/073/421194073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010438,
-    "geom:area_square_m":126944188.744578,
+    "geom:area_square_m":126944270.161378,
     "geom:bbox":"-66.846323,10.34803,-66.70148,10.461922",
     "geom:latitude":10.400433,
     "geom:longitude":-66.788869,
@@ -163,12 +163,13 @@
         "wd:id":"Q975765",
         "wk:page":"El Hatillo Town, Venezuela"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38bdf713675eb55c03d9bf4e7c26635d",
+    "wof:geomhash":"490e7bff46bee349e641732bb14a19ff",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421194073,
-    "wof:lastmodified":1690915034,
+    "wof:lastmodified":1695886189,
     "wof:name":"El Hatillo",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/194/991/421194991.geojson
+++ b/data/421/194/991/421194991.geojson
@@ -81,6 +81,7 @@
         "hasc:id":"VE.AR.BO",
         "qs_pg:id":114640
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009827,
     "wof:geom_alt":[
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":421194991,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886195,
     "wof:name":"Bolivar",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/194/993/421194993.geojson
+++ b/data/421/194/993/421194993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0294,
-    "geom:area_square_m":359191513.147595,
+    "geom:area_square_m":359191078.885157,
     "geom:bbox":"-70.811263,8.750203,-70.546325,9.014216",
     "geom:latitude":8.871442,
     "geom:longitude":-70.676896,
@@ -123,12 +123,13 @@
         "qs_pg:id":114641,
         "wd:id":"Q2706815"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009827,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e50a321da9c82db164f1f8e789fadd3",
+    "wof:geomhash":"1c4e209db8eef6ae54345ad27a7b4e9f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421194993,
-    "wof:lastmodified":1690915033,
+    "wof:lastmodified":1695886189,
     "wof:name":"Cardenal Quintero",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/195/115/421195115.geojson
+++ b/data/421/195/115/421195115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016303,
-    "geom:area_square_m":199664958.418228,
+    "geom:area_square_m":199664863.68222,
     "geom:bbox":"-72.368826,7.871293,-72.147747,8.014477",
     "geom:latitude":7.933139,
     "geom:longitude":-72.280872,
@@ -127,12 +127,13 @@
         "qs_pg:id":576568,
         "wd:id":"Q2779125"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009832,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb9351da3591a6927a930b72aeb22c42",
+    "wof:geomhash":"f5253920758544d8aac235d4e2c15b22",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421195115,
-    "wof:lastmodified":1690915032,
+    "wof:lastmodified":1695886189,
     "wof:name":"Lobatera",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/195/493/421195493.geojson
+++ b/data/421/195/493/421195493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008925,
-    "geom:area_square_m":109370239.532996,
+    "geom:area_square_m":109370262.322828,
     "geom:bbox":"-72.240928,7.62,-72.070663,7.704018",
     "geom:latitude":7.662901,
     "geom:longitude":-72.156649,
@@ -356,12 +356,13 @@
         "qs_pg:id":114574,
         "wd:id":"Q224244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009850,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5e0dd5b3bc0ac97820c5b8812480231",
+    "wof:geomhash":"03011593415d89fa440ba8b18e742b30",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -371,7 +372,7 @@
         }
     ],
     "wof:id":421195493,
-    "wof:lastmodified":1690915031,
+    "wof:lastmodified":1695886189,
     "wof:name":"Torbes",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/195/495/421195495.geojson
+++ b/data/421/195/495/421195495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044288,
-    "geom:area_square_m":538537441.675185,
+    "geom:area_square_m":538537322.289396,
     "geom:bbox":"-68.399778,10.301235,-68.139503,10.58831",
     "geom:latitude":10.454134,
     "geom:longitude":-68.264338,
@@ -170,12 +170,13 @@
         "qs_pg:id":114593,
         "wd:id":"Q1710527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009850,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc981e2412c324a645759b69242cf095",
+    "wof:geomhash":"987872b04349a38b975add653de706a3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421195495,
-    "wof:lastmodified":1690915031,
+    "wof:lastmodified":1695886189,
     "wof:name":"Juan Jose Mora",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/195/497/421195497.geojson
+++ b/data/421/195/497/421195497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.811983,
-    "geom:area_square_m":9929936458.905724,
+    "geom:area_square_m":9929936018.384977,
     "geom:bbox":"-66.3104,7.678927,-65.610413,9.61",
     "geom:latitude":8.491804,
     "geom:longitude":-65.988118,
@@ -251,7 +251,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c48ab534c26ac02f068f54147461f6a9",
+    "wof:geomhash":"a20b8e499a693ae129176063c2871d97",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -261,7 +261,7 @@
         }
     ],
     "wof:id":421195497,
-    "wof:lastmodified":1690915030,
+    "wof:lastmodified":1695886189,
     "wof:name":"Infante",
     "wof:parent_id":85680543,
     "wof:placetype":"county",

--- a/data/421/195/501/421195501.geojson
+++ b/data/421/195/501/421195501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001538,
-    "geom:area_square_m":18717133.413092,
+    "geom:area_square_m":18717194.196393,
     "geom:bbox":"-67.574479,10.19,-67.493043,10.227348",
     "geom:latitude":10.207577,
     "geom:longitude":-67.529805,
@@ -187,12 +187,13 @@
         "qs_pg:id":114619,
         "wd:id":"Q2843795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009850,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d8744f3f1aa54f41bc72a7136d316a0a",
+    "wof:geomhash":"90acf12257a8dc396c0ddba836d7dd17",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":421195501,
-    "wof:lastmodified":1690915031,
+    "wof:lastmodified":1695886189,
     "wof:name":"Francisco Linares Alcantara",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/195/503/421195503.geojson
+++ b/data/421/195/503/421195503.geojson
@@ -81,6 +81,7 @@
         "hasc:id":"VE.AR.BO",
         "qs_pg:id":114620
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009850,
     "wof:geom_alt":[
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":421195503,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886195,
     "wof:name":"Bolivar",
     "wof:parent_id":85680561,
     "wof:placetype":"county",

--- a/data/421/195/505/421195505.geojson
+++ b/data/421/195/505/421195505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021069,
-    "geom:area_square_m":258041879.080125,
+    "geom:area_square_m":258041830.961343,
     "geom:bbox":"-71.987277,7.820382,-71.779091,8.034788",
     "geom:latitude":7.915444,
     "geom:longitude":-71.894934,
@@ -215,12 +215,13 @@
         "qs_pg:id":114621,
         "wd:id":"Q311447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009850,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"380c4a90c9e6412c619b93cba6c8a47f",
+    "wof:geomhash":"3949216448d392af9a7faa4b7e8ce8ec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":421195505,
-    "wof:lastmodified":1690915029,
+    "wof:lastmodified":1695886188,
     "wof:name":"Francisco De Miranda",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/196/155/421196155.geojson
+++ b/data/421/196/155/421196155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044129,
-    "geom:area_square_m":540140460.71348,
+    "geom:area_square_m":540140637.791456,
     "geom:bbox":"-71.823552,8.010628,-71.561283,8.300277",
     "geom:latitude":8.158086,
     "geom:longitude":-71.688006,
@@ -124,12 +124,13 @@
         "qs_pg:id":957426,
         "wd:id":"Q2607198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009871,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6bdde3bfb7ce713a85db9847f1b481af",
+    "wof:geomhash":"b8ea0fff1fce679e377288cd1387ef60",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421196155,
-    "wof:lastmodified":1690915093,
+    "wof:lastmodified":1695886197,
     "wof:name":"Guaraque",
     "wof:parent_id":85680473,
     "wof:placetype":"county",

--- a/data/421/196/939/421196939.geojson
+++ b/data/421/196/939/421196939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020449,
-    "geom:area_square_m":250523110.579354,
+    "geom:area_square_m":250523366.004241,
     "geom:bbox":"-72.263937,7.693916,-71.969922,7.855914",
     "geom:latitude":7.791165,
     "geom:longitude":-72.093422,
@@ -173,12 +173,13 @@
         "qs_pg:id":912043,
         "wd:id":"Q2621527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009898,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd93269bc663d66081e7ee243bd50de0",
+    "wof:geomhash":"a843cf9aca7e1b50816e15de3be22665",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":421196939,
-    "wof:lastmodified":1690915091,
+    "wof:lastmodified":1695886196,
     "wof:name":"Cardenas",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/196/977/421196977.geojson
+++ b/data/421/196/977/421196977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.257373,
-    "geom:area_square_m":3124940471.471668,
+    "geom:area_square_m":3124940508.206102,
     "geom:bbox":"-72.682442,10.766943,-71.661366,11.097641",
     "geom:latitude":10.909949,
     "geom:longitude":-72.164739,
@@ -199,12 +199,13 @@
         "qs_pg:id":1263754,
         "wd:id":"Q1820462"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de5793de6c4c76ead1a576a30328d6d7",
+    "wof:geomhash":"0c49f03f5eaa9ba128a23ff11b042676",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":421196977,
-    "wof:lastmodified":1690915091,
+    "wof:lastmodified":1695886195,
     "wof:name":"Mara",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/196/979/421196979.geojson
+++ b/data/421/196/979/421196979.geojson
@@ -111,6 +111,7 @@
         "hasc:id":"VE.BO.CE",
         "qs_pg:id":1263768
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009899,
     "wof:geom_alt":[
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421196979,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886195,
     "wof:name":"Cede\u00f1o",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/196/981/421196981.geojson
+++ b/data/421/196/981/421196981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.650897,
-    "geom:area_square_m":57213668136.88842,
+    "geom:area_square_m":57213668308.35083,
     "geom:bbox":"-64.300938,3.608207,-62.10089,7.999846",
     "geom:latitude":5.707104,
     "geom:longitude":-63.264163,
@@ -178,12 +178,13 @@
         "qs_pg:id":1263769,
         "wd:id":"Q1651292"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aaca0f092b31d48054fb62589f9ab144",
+    "wof:geomhash":"ee9613e69dcb1c3acb8985d183834c54",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":421196981,
-    "wof:lastmodified":1690915094,
+    "wof:lastmodified":1695886197,
     "wof:name":"Raul Leoni",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/196/983/421196983.geojson
+++ b/data/421/196/983/421196983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002788,
-    "geom:area_square_m":33836927.625184,
+    "geom:area_square_m":33836897.880979,
     "geom:bbox":"-64.015151,11.030274,-63.948592,11.113769",
     "geom:latitude":11.060862,
     "geom:longitude":-63.978113,
@@ -152,12 +152,13 @@
         "qs_pg:id":1263800,
         "wd:id":"Q748134"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009899,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"03a4add001a8bb0e70c1138c69b82462",
+    "wof:geomhash":"5631690136fb25bbfa61f44b2b206029",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421196983,
-    "wof:lastmodified":1690915092,
+    "wof:lastmodified":1695886196,
     "wof:name":"Marcano",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/197/623/421197623.geojson
+++ b/data/421/197/623/421197623.geojson
@@ -77,6 +77,7 @@
         "hasc:id":"VE.BO.PI",
         "qs_pg:id":368893
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009919,
     "wof:geom_alt":[
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":421197623,
-    "wof:lastmodified":1694492875,
+    "wof:lastmodified":1695886377,
     "wof:name":"Piar",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/198/089/421198089.geojson
+++ b/data/421/198/089/421198089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040151,
-    "geom:area_square_m":488300828.57071,
+    "geom:area_square_m":488301136.578688,
     "geom:bbox":"-68.17,10.320201,-67.868349,10.50375",
     "geom:latitude":10.413093,
     "geom:longitude":-68.027171,
@@ -265,12 +265,13 @@
         "wd:id":"Q3410570",
         "wk:page":"Puerto Cabello"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009936,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd80a7993f4bd736e9ee221be000b990",
+    "wof:geomhash":"ed1ce0cd85248bd3fca030e692ab6a90",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -280,7 +281,7 @@
         }
     ],
     "wof:id":421198089,
-    "wof:lastmodified":1690915090,
+    "wof:lastmodified":1695886196,
     "wof:name":"Puerto Cabello",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/198/671/421198671.geojson
+++ b/data/421/198/671/421198671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.120583,
-    "geom:area_square_m":26031872351.61021,
+    "geom:area_square_m":26031872316.856163,
     "geom:bbox":"-62.815,5.871456,-60.279285,7.977992",
     "geom:latitude":6.871687,
     "geom:longitude":-61.398334,
@@ -121,12 +121,13 @@
         "qs_pg:id":430284,
         "wd:id":"Q2450334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459009956,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41c1cd7ff6f160872fbb6e7d8320a05e",
+    "wof:geomhash":"742e93aa3e93bd9dfccadf890b78f500",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421198671,
-    "wof:lastmodified":1690915090,
+    "wof:lastmodified":1695886196,
     "wof:name":"Sifontes",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/200/093/421200093.geojson
+++ b/data/421/200/093/421200093.geojson
@@ -181,6 +181,7 @@
         "hasc:id":"VE.CO.SC",
         "qs_pg:id":772411
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010011,
     "wof:geom_alt":[
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421200093,
-    "wof:lastmodified":1694492945,
+    "wof:lastmodified":1695886197,
     "wof:name":"San Carlos",
     "wof:parent_id":85680491,
     "wof:placetype":"county",

--- a/data/421/200/611/421200611.geojson
+++ b/data/421/200/611/421200611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18547,
-    "geom:area_square_m":2260724074.501799,
+    "geom:area_square_m":2260723887.608714,
     "geom:bbox":"-70.120592,9.407409,-69.617874,10.015192",
     "geom:latitude":9.6786,
     "geom:longitude":-69.867955,
@@ -191,12 +191,13 @@
         "qs_pg:id":209356,
         "wd:id":"Q2511946"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010031,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ba6f8ab3dc596391930f974d612ea32d",
+    "wof:geomhash":"e1e6e86803539eb60abb66109327868f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421200611,
-    "wof:lastmodified":1690915098,
+    "wof:lastmodified":1695886197,
     "wof:name":"Moran",
     "wof:parent_id":85680499,
     "wof:placetype":"county",

--- a/data/421/201/567/421201567.geojson
+++ b/data/421/201/567/421201567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170155,
-    "geom:area_square_m":2063137278.054111,
+    "geom:area_square_m":2063137507.474169,
     "geom:bbox":"-72.497505,11.001027,-71.331798,11.840865",
     "geom:latitude":11.308761,
     "geom:longitude":-71.978263,
@@ -90,12 +90,13 @@
         "hasc:id":"VE.ZU.PA",
         "qs_pg:id":1263753
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6f4a349ab8b4ea6c161379e27bb8e05d",
+    "wof:geomhash":"4685939c8c6adba4f1cb81dcbb88547b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421201567,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Paez",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/201/571/421201571.geojson
+++ b/data/421/201/571/421201571.geojson
@@ -78,6 +78,7 @@
         "hasc:id":"VE.AN.SB",
         "qs_pg:id":1263756
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010077,
     "wof:geom_alt":[
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":421201571,
-    "wof:lastmodified":1694492884,
+    "wof:lastmodified":1695886399,
     "wof:name":"Simon Bolivar",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/202/057/421202057.geojson
+++ b/data/421/202/057/421202057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040894,
-    "geom:area_square_m":498761409.641576,
+    "geom:area_square_m":498760334.898896,
     "geom:bbox":"-69.233454,9.352659,-68.844098,9.577234",
     "geom:latitude":9.478823,
     "geom:longitude":-69.032413,
@@ -120,12 +120,13 @@
         "qs_pg:id":219077,
         "wd:id":"Q3038839"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010103,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90a5d022800fccb6878374461ee4917a",
+    "wof:geomhash":"0da74e1bfba2036e308c359a804412c8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421202057,
-    "wof:lastmodified":1690915047,
+    "wof:lastmodified":1695886191,
     "wof:name":"Paez",
     "wof:parent_id":85680503,
     "wof:placetype":"county",

--- a/data/421/202/059/421202059.geojson
+++ b/data/421/202/059/421202059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04723,
-    "geom:area_square_m":574393948.573911,
+    "geom:area_square_m":574394314.794145,
     "geom:bbox":"-71.477943,10.319162,-70.892516,10.476047",
     "geom:latitude":10.408913,
     "geom:longitude":-71.231635,
@@ -120,12 +120,13 @@
         "qs_pg:id":219078,
         "wd:id":"Q5116306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010103,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47982b40d9716b9fbc1db59dfc31ac1c",
+    "wof:geomhash":"5d4267b21312eace5ed384763e8dfa91",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421202059,
-    "wof:lastmodified":1690915047,
+    "wof:lastmodified":1695886195,
     "wof:name":"Cabimas",
     "wof:parent_id":85680487,
     "wof:placetype":"county",

--- a/data/421/202/063/421202063.geojson
+++ b/data/421/202/063/421202063.geojson
@@ -194,6 +194,7 @@
         "hasc:id":"VE.AR.ZA",
         "qs_pg:id":219080
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010103,
     "wof:geom_alt":[
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":421202063,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886195,
     "wof:name":"Zamora",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/202/065/421202065.geojson
+++ b/data/421/202/065/421202065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015172,
-    "geom:area_square_m":185775672.861333,
+    "geom:area_square_m":185775650.105129,
     "geom:bbox":"-72.145657,7.93,-72.019145,8.113303",
     "geom:latitude":8.019386,
     "geom:longitude":-72.081287,
@@ -344,12 +344,13 @@
         "qs_pg:id":219081,
         "wd:id":"Q2358589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010103,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c255ae6ac75fecfc8a3820239f3cbe05",
+    "wof:geomhash":"e0032fb516c0b8d69b64c1b03443ba06",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -359,7 +360,7 @@
         }
     ],
     "wof:id":421202065,
-    "wof:lastmodified":1690915044,
+    "wof:lastmodified":1695886190,
     "wof:name":"Jose Maria Vargas",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/202/067/421202067.geojson
+++ b/data/421/202/067/421202067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036201,
-    "geom:area_square_m":443061698.013152,
+    "geom:area_square_m":443061892.411537,
     "geom:bbox":"-72.041528,8.01,-71.8611,8.386081",
     "geom:latitude":8.195184,
     "geom:longitude":-71.953317,
@@ -127,12 +127,13 @@
         "qs_pg:id":219082,
         "wd:id":"Q2608254"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010103,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"873d00cbbc905dd22a4d9fabc301c849",
+    "wof:geomhash":"fa11921ee7a1b3cdfba76f14f86620e6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421202067,
-    "wof:lastmodified":1690915049,
+    "wof:lastmodified":1695886191,
     "wof:name":"Jauregui",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/202/069/421202069.geojson
+++ b/data/421/202/069/421202069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00701,
-    "geom:area_square_m":85057712.413856,
+    "geom:area_square_m":85057846.320199,
     "geom:bbox":"-63.977996,11.028174,-63.879986,11.145967",
     "geom:latitude":11.08562,
     "geom:longitude":-63.920994,
@@ -174,12 +174,13 @@
         "qs_pg:id":219083,
         "wd:id":"Q2451657"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010104,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3390e22821d3b33520f90d54f069f5c6",
+    "wof:geomhash":"398c6618cad939afaeb9d58fbb5c2008",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":421202069,
-    "wof:lastmodified":1690915048,
+    "wof:lastmodified":1695886191,
     "wof:name":"Gomez",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/421/202/369/421202369.geojson
+++ b/data/421/202/369/421202369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.778233,
-    "geom:area_square_m":34210045044.924721,
+    "geom:area_square_m":34210044193.686653,
     "geom:bbox":"-62.92095,4.077689,-60.5889,6.32659",
     "geom:latitude":5.214152,
     "geom:longitude":-61.809595,
@@ -152,12 +152,13 @@
         "qs_pg:id":221562,
         "wd:id":"Q3113406"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010115,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37617dbee3a779b52cc140fa14d5294a",
+    "wof:geomhash":"e4bb2982e01e202272820a974da79adb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421202369,
-    "wof:lastmodified":1690915046,
+    "wof:lastmodified":1695886191,
     "wof:name":"Gran Sabana",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/202/371/421202371.geojson
+++ b/data/421/202/371/421202371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.511622,
-    "geom:area_square_m":6276004559.263817,
+    "geom:area_square_m":6276005386.422649,
     "geom:bbox":"-62.481988,6.33,-61.495017,7.951124",
     "geom:latitude":7.217935,
     "geom:longitude":-62.051599,
@@ -132,12 +132,13 @@
         "qs_pg:id":221563,
         "wd:id":"Q2100029"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010115,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c5da6f0d5999304b44a249c502ba2ba",
+    "wof:geomhash":"e2e7d3b0b1540926fbf0120c89be3778",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421202371,
-    "wof:lastmodified":1690915045,
+    "wof:lastmodified":1695886191,
     "wof:name":"Roscio",
     "wof:parent_id":85680517,
     "wof:placetype":"county",

--- a/data/421/202/373/421202373.geojson
+++ b/data/421/202/373/421202373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064421,
-    "geom:area_square_m":784474216.319852,
+    "geom:area_square_m":784474216.320049,
     "geom:bbox":"-68.129664,9.820449,-67.802921,10.238994",
     "geom:latitude":9.999635,
     "geom:longitude":-67.97307,
@@ -142,6 +142,7 @@
         "qs_pg:id":221564,
         "wd:id":"Q3553547"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421186751
     ],
@@ -150,7 +151,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ce59c46730ab66acbe4d5ca6bae23a0",
+    "wof:geomhash":"5a6f89fc3c6c6601a12e4510948355b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":421202373,
-    "wof:lastmodified":1690915050,
+    "wof:lastmodified":1695886195,
     "wof:name":"Valencia",
     "wof:parent_id":85680493,
     "wof:placetype":"county",

--- a/data/421/202/375/421202375.geojson
+++ b/data/421/202/375/421202375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066855,
-    "geom:area_square_m":813447034.298988,
+    "geom:area_square_m":813446204.259101,
     "geom:bbox":"-67.22,10.055794,-66.822069,10.437847",
     "geom:latitude":10.264773,
     "geom:longitude":-67.036529,
@@ -130,12 +130,13 @@
         "qs_pg:id":221565,
         "wd:id":"Q1090454"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010116,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82e80c4ac87312a2477e942d01565333",
+    "wof:geomhash":"79503f7926dc9bca4780c2578a5d2b47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421202375,
-    "wof:lastmodified":1690915050,
+    "wof:lastmodified":1695886192,
     "wof:name":"Guaicaipuro",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/202/591/421202591.geojson
+++ b/data/421/202/591/421202591.geojson
@@ -89,6 +89,7 @@
         "hasc:id":"VE.AR.LI",
         "qs_pg:id":224833
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010123,
     "wof:geom_alt":[
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421202591,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886192,
     "wof:name":"Libertador",
     "wof:parent_id":85680535,
     "wof:placetype":"county",

--- a/data/421/202/593/421202593.geojson
+++ b/data/421/202/593/421202593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.637183,
-    "geom:area_square_m":7809046532.709093,
+    "geom:area_square_m":7809046426.978923,
     "geom:bbox":"-69.894257,7.15635,-68.816127,8.071767",
     "geom:latitude":7.6316,
     "geom:longitude":-69.291044,
@@ -149,12 +149,13 @@
         "qs_pg:id":224834,
         "wd:id":"Q2537345"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010123,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8059bf84b7d10ce3c550e10ba6f4935c",
+    "wof:geomhash":"d2c5fd6dfbe6bd8f98d978f6f6f2d597",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421202593,
-    "wof:lastmodified":1690915044,
+    "wof:lastmodified":1695886190,
     "wof:name":"Mu\u00f1oz",
     "wof:parent_id":85680465,
     "wof:placetype":"county",

--- a/data/421/203/373/421203373.geojson
+++ b/data/421/203/373/421203373.geojson
@@ -108,6 +108,7 @@
         "hasc:id":"VE.AR.SM",
         "qs_pg:id":61016
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010149,
     "wof:geom_alt":[
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":421203373,
-    "wof:lastmodified":1694492945,
+    "wof:lastmodified":1695886196,
     "wof:name":"Bolivar",
     "wof:parent_id":85680525,
     "wof:placetype":"county",

--- a/data/421/203/511/421203511.geojson
+++ b/data/421/203/511/421203511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023753,
-    "geom:area_square_m":291113745.118416,
+    "geom:area_square_m":291113745.118261,
     "geom:bbox":"-72.44,7.43335036531,-72.2786829965,7.78",
     "geom:latitude":7.63263,
     "geom:longitude":-72.36422,
@@ -143,12 +143,13 @@
         "qs_pg:id":232495,
         "wd:id":"Q591314"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010155,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1768efd2e34bdb661de0a6df1d00ff91",
+    "wof:geomhash":"45c31f348fa5887f3ee1afd89f6bcf7e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421203511,
-    "wof:lastmodified":1582393017,
+    "wof:lastmodified":1695886190,
     "wof:name":"Junin",
     "wof:parent_id":85680481,
     "wof:placetype":"county",

--- a/data/421/203/565/421203565.geojson
+++ b/data/421/203/565/421203565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302021,
-    "geom:area_square_m":3695953412.191576,
+    "geom:area_square_m":3695953412.193247,
     "geom:bbox":"-69.5393783759,7.89674264868,-68.6383333333,8.69388464949",
     "geom:latitude":8.242464,
     "geom:longitude":-69.181361,
@@ -157,12 +157,13 @@
         "qs_pg:id":233580,
         "wd:id":"Q3089933"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"220201e8a1f6fd7af53070f7f5ff1188",
+    "wof:geomhash":"2a3e881fc171552f01c67cc4fda51244",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421203565,
-    "wof:lastmodified":1582393017,
+    "wof:lastmodified":1695886190,
     "wof:name":"Sosa",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/421/203/571/421203571.geojson
+++ b/data/421/203/571/421203571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.570369,
-    "geom:area_square_m":6975553007.194739,
+    "geom:area_square_m":6975553135.645644,
     "geom:bbox":"-63.99,8.098333,-62.680171,8.9525",
     "geom:latitude":8.482105,
     "geom:longitude":-63.438233,
@@ -130,12 +130,13 @@
         "qs_pg:id":233694,
         "wd:id":"Q353807"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c96b87d7ae7849fbc5b0a81359627b1",
+    "wof:geomhash":"bf1e15839a7b821a4fd58ae5a2e53c3b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421203571,
-    "wof:lastmodified":1690915043,
+    "wof:lastmodified":1695886195,
     "wof:name":"Independencia",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/421/204/299/421204299.geojson
+++ b/data/421/204/299/421204299.geojson
@@ -99,6 +99,7 @@
         "hasc:id":"VE.AP.PA",
         "qs_pg:id":239107
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010180,
     "wof:geom_alt":[
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":421204299,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886190,
     "wof:name":"Paez",
     "wof:parent_id":85680553,
     "wof:placetype":"county",

--- a/data/421/204/789/421204789.geojson
+++ b/data/421/204/789/421204789.geojson
@@ -90,6 +90,7 @@
         "hasc:id":"VE.AN.IN",
         "qs_pg:id":248847
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010198,
     "wof:geom_alt":[
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421204789,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886195,
     "wof:name":"San Felipe",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/421/204/791/421204791.geojson
+++ b/data/421/204/791/421204791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017125,
-    "geom:area_square_m":208433309.781102,
+    "geom:area_square_m":208433461.872589,
     "geom:bbox":"-64.675446,10.096508,-64.439018,10.305414",
     "geom:latitude":10.165435,
     "geom:longitude":-64.549732,
@@ -88,12 +88,13 @@
         "qs_pg:id":248848,
         "wd:id":"Q6298891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1459010198,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"19c30426d597faafa8eceaaac2672aa1",
+    "wof:geomhash":"1b8cf895b68e69ebe767dbbe4c0386e4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421204791,
-    "wof:lastmodified":1627522972,
+    "wof:lastmodified":1695886182,
     "wof:name":"Sotillo",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/856/323/17/85632317.geojson
+++ b/data/856/323/17/85632317.geojson
@@ -1278,6 +1278,7 @@
         "hasc:id":"VE",
         "icao:code":"YV",
         "ioc:id":"VEN",
+        "iso:code":"VE",
         "itu:id":"VEN",
         "loc:id":"n78095508",
         "m49:code":"862",
@@ -1292,6 +1293,7 @@
         "wk:page":"Venezuela",
         "wmo:id":"VN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:country_alpha3":"VEN",
     "wof:geom_alt":[
@@ -1315,7 +1317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639652,
+    "wof:lastmodified":1695881313,
     "wof:name":"Venezuela",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/804/61/85680461.geojson
+++ b/data/856/804/61/85680461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.338324,
-    "geom:area_square_m":28375028523.046772,
+    "geom:area_square_m":28375027293.235767,
     "geom:bbox":"-71.315019,10.3,-68.217918,12.202473",
     "geom:latitude":11.07274,
     "geom:longitude":-69.773291,
@@ -377,17 +377,19 @@
         "gn:id":3640873,
         "gp:id":2347687,
         "hasc:id":"VE.FA",
+        "iso:code":"VE-I",
         "iso:id":"VE-I",
         "qs_pg:id":1285594,
         "unlc:id":"VE-I",
         "wd:id":"Q202071",
         "wk:page":"Falc\u00f3n"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9259a0da2231b2acaf50601e9b2742f5",
+    "wof:geomhash":"4bf43dc609ef1d23be08a7712bd93636",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -402,7 +404,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914954,
+    "wof:lastmodified":1695884382,
     "wof:name":"Falc\u00f3n",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/65/85680465.geojson
+++ b/data/856/804/65/85680465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.031217,
-    "geom:area_square_m":73997602451.733459,
+    "geom:area_square_m":73997601706.497223,
     "geom:bbox":"-72.409931,6.060355,-66.327632,8.071767",
     "geom:latitude":7.133439,
     "geom:longitude":-68.808652,
@@ -375,17 +375,19 @@
         "gn:id":3649151,
         "gp:id":2347679,
         "hasc:id":"VE.AP",
+        "iso:code":"VE-C",
         "iso:id":"VE-C",
         "qs_pg:id":895015,
         "unlc:id":"VE-C",
         "wd:id":"Q41146",
         "wk:page":"Apure"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17bcd688a97a803b9fb6b4ff2a9914b6",
+    "wof:geomhash":"e8e9535bc3e51e53f86bbdfe89166939",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914958,
+    "wof:lastmodified":1695884967,
     "wof:name":"Apure",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/69/85680469.geojson
+++ b/data/856/804/69/85680469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.022029,
-    "geom:area_square_m":36989686331.121544,
+    "geom:area_square_m":36989686085.839516,
     "geom:bbox":"-71.863376,7.297773,-67.500767,9.061368",
     "geom:latitude":8.151281,
     "geom:longitude":-69.854128,
@@ -400,17 +400,19 @@
         "gn:id":3648544,
         "gp:id":2347681,
         "hasc:id":"VE.BA",
+        "iso:code":"VE-E",
         "iso:id":"VE-E",
         "qs_pg:id":1083882,
         "unlc:id":"VE-E",
         "wd:id":"Q43271",
         "wk:page":"Barinas (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ed005fe0a16edb12049eaabdfd751e8",
+    "wof:geomhash":"cc2286711584a14761a0d7763b500757",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -425,7 +427,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914955,
+    "wof:lastmodified":1695884966,
     "wof:name":"Barinas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/73/85680473.geojson
+++ b/data/856/804/73/85680473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.973337,
-    "geom:area_square_m":11902743396.582533,
+    "geom:area_square_m":11902742530.152174,
     "geom:bbox":"-71.910879,7.671281,-70.546325,9.201781",
     "geom:latitude":8.511923,
     "geom:longitude":-71.261673,
@@ -389,17 +389,19 @@
         "gn:id":3632306,
         "gp:id":2347690,
         "hasc:id":"VE.ME",
+        "iso:code":"VE-L",
         "iso:id":"VE-L",
         "qs_pg:id":219632,
         "unlc:id":"VE-L",
         "wd:id":"Q165582",
         "wk:page":"M\u00e9rida (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0d913417a7ec57648ed5ae0d760421a",
+    "wof:geomhash":"860853d00b4c9ef4a13be19c9557a498",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -414,7 +416,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914956,
+    "wof:lastmodified":1695884382,
     "wof:name":"M\u00e9rida",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/81/85680481.geojson
+++ b/data/856/804/81/85680481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.874231,
-    "geom:area_square_m":10706198001.996941,
+    "geom:area_square_m":10706197407.451357,
     "geom:bbox":"-72.48739,7.364501,-71.322628,8.659895",
     "geom:latitude":7.941429,
     "geom:longitude":-72.026173,
@@ -370,17 +370,19 @@
         "gn:id":3626553,
         "gp:id":2347696,
         "hasc:id":"VE.TA",
+        "iso:code":"VE-S",
         "iso:id":"VE-S",
         "qs_pg:id":235661,
         "unlc:id":"VE-S",
         "wd:id":"Q41144",
         "wk:page":"T\u00e1chira"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b861ed56095a5b13ea1953bd902aa067",
+    "wof:geomhash":"2b0085d04452846a18f54f0a6aa61d0c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -395,7 +397,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914957,
+    "wof:lastmodified":1695884382,
     "wof:name":"T\u00e1chira",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/83/85680483.geojson
+++ b/data/856/804/83/85680483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.687931,
-    "geom:area_square_m":8391024412.114122,
+    "geom:area_square_m":8391024192.124568,
     "geom:bbox":"-71.090057,8.961172,-69.99861,10.038075",
     "geom:latitude":9.444469,
     "geom:longitude":-70.512569,
@@ -350,17 +350,19 @@
         "gn:id":3625974,
         "gp:id":2347697,
         "hasc:id":"VE.TR",
+        "iso:code":"VE-T",
         "iso:id":"VE-T",
         "qs_pg:id":219634,
         "unlc:id":"VE-T",
         "wd:id":"Q202068",
         "wk:page":"Trujillo (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ff4805a616ef60e2a23cdfac9107a1d",
+    "wof:geomhash":"3c466938476fe26323257fd30daa438a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914959,
+    "wof:lastmodified":1695884967,
     "wof:name":"Trujillo",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/87/85680487.geojson
+++ b/data/856/804/87/85680487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.629987,
-    "geom:area_square_m":44211131533.103729,
+    "geom:area_square_m":44211129967.786674,
     "geom:bbox":"-73.351558,8.365017,-70.668584,11.840865",
     "geom:latitude":9.916882,
     "geom:longitude":-72.083732,
@@ -374,6 +374,7 @@
         "gn:id":3625035,
         "gp:id":2347699,
         "hasc:id":"VE.ZU",
+        "iso:code":"VE-V",
         "iso:id":"VE-V",
         "loc:id":"n79089267",
         "qs_pg:id":219636,
@@ -381,11 +382,12 @@
         "wd:id":"Q43269",
         "wk:page":"Zulia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b5f636c224089eb916b5d5fe407d4a7",
+    "wof:geomhash":"a1ce3cff3f9c1a7ef13981e5667687a1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914956,
+    "wof:lastmodified":1695884967,
     "wof:name":"Zulia",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/91/85680491.geojson
+++ b/data/856/804/91/85680491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.138437,
-    "geom:area_square_m":13890117660.286713,
+    "geom:area_square_m":13890118096.88632,
     "geom:bbox":"-68.982513,8.538387,-67.750301,10.08053",
     "geom:latitude":9.338917,
     "geom:longitude":-68.34685,
@@ -371,17 +371,19 @@
         "gn:id":3645386,
         "gp:id":2347684,
         "hasc:id":"VE.CO",
+        "iso:code":"VE-H",
         "iso:id":"VE-H",
         "qs_pg:id":895018,
         "unlc:id":"VE-H",
         "wd:id":"Q205460",
         "wk:page":"Cojedes (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a40bb7e9c6cc7980519ff11143610c85",
+    "wof:geomhash":"158c37017bec1f8e1547ab952c0ae3c7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -396,7 +398,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914958,
+    "wof:lastmodified":1695885131,
     "wof:name":"Cojedes",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/93/85680493.geojson
+++ b/data/856/804/93/85680493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423846,
-    "geom:area_square_m":5158472912.84829,
+    "geom:area_square_m":5158473414.029793,
     "geom:bbox":"-68.42201,9.820449,-67.518118,10.58831",
     "geom:latitude":10.175807,
     "geom:longitude":-68.0167,
@@ -384,17 +384,19 @@
         "gn:id":3646751,
         "gp:id":2347683,
         "hasc:id":"VE.CA",
+        "iso:code":"VE-G",
         "iso:id":"VE-G",
         "qs_pg:id":895017,
         "unlc:id":"VE-G",
         "wd:id":"Q191186",
         "wk:page":"Carabobo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d4879cecdb9399786145e47e2fdc45af",
+    "wof:geomhash":"fa952de9934c0b0cddbd7215fd1e8ee3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -409,7 +411,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914955,
+    "wof:lastmodified":1695884967,
     "wof:name":"Carabobo",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/804/99/85680499.geojson
+++ b/data/856/804/99/85680499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.590264,
-    "geom:area_square_m":19355652854.677357,
+    "geom:area_square_m":19355652995.161076,
     "geom:bbox":"-70.877193,9.407409,-68.872677,10.748873",
     "geom:latitude":10.153971,
     "geom:longitude":-69.785818,
@@ -381,17 +381,19 @@
         "gn:id":3636539,
         "gp:id":2347689,
         "hasc:id":"VE.LA",
+        "iso:code":"VE-K",
         "iso:id":"VE-K",
         "qs_pg:id":1285595,
         "unlc:id":"VE-K",
         "wd:id":"Q205796",
         "wk:page":"Lara (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f05302bdcf9cafa748601e95e7cb8a9c",
+    "wof:geomhash":"77e702cd97bbfd69a66d5b486de08236",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -406,7 +408,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914959,
+    "wof:lastmodified":1695884967,
     "wof:name":"Lara",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/03/85680503.geojson
+++ b/data/856/805/03/85680503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.447658,
-    "geom:area_square_m":17678332771.788078,
+    "geom:area_square_m":17678332228.998047,
     "geom:bbox":"-70.193068,8.096068,-68.513322,9.841667",
     "geom:latitude":9.031213,
     "geom:longitude":-69.272556,
@@ -341,17 +341,19 @@
         "gn:id":3629941,
         "gp:id":2347694,
         "hasc:id":"VE.PO",
+        "iso:code":"VE-P",
         "iso:id":"VE-P",
         "qs_pg:id":1047657,
         "unlc:id":"VE-P",
         "wd:id":"Q205784",
         "wk:page":"Portuguesa (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5a380b402b43b72b281d3ed000f26cc",
+    "wof:geomhash":"e42be5299b4376d3305697d1bc784ae4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914961,
+    "wof:lastmodified":1695884967,
     "wof:name":"Portuguesa",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/07/85680507.geojson
+++ b/data/856/805/07/85680507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501695,
-    "geom:area_square_m":6104254636.242161,
+    "geom:area_square_m":6104253776.938426,
     "geom:bbox":"-69.208959,9.840833,-68.26,10.768718",
     "geom:latitude":10.262946,
     "geom:longitude":-68.737792,
@@ -339,17 +339,19 @@
         "gn:id":3625210,
         "gp:id":2347698,
         "hasc:id":"VE.YA",
+        "iso:code":"VE-U",
         "iso:id":"VE-U",
         "qs_pg:id":219635,
         "unlc:id":"VE-U",
         "wd:id":"Q201121",
         "wk:page":"Yaracuy"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d75969ff80c95d8e88e85b4f2482510",
+    "wof:geomhash":"0525e96cef9846c6aa9d968b2c9b1a7b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -364,7 +366,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914965,
+    "wof:lastmodified":1695884968,
     "wof:name":"Yaracuy",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/11/85680511.geojson
+++ b/data/856/805/11/85680511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":14.625877,
-    "geom:area_square_m":180489273285.242767,
+    "geom:area_square_m":180489272366.488281,
     "geom:bbox":"-67.862538,0.647529,-63.363197,6.2",
     "geom:latitude":3.374527,
     "geom:longitude":-65.945603,
@@ -411,17 +411,19 @@
         "gn:id":3649302,
         "gp:id":2347677,
         "hasc:id":"VE.AM",
+        "iso:code":"VE-Z",
         "iso:id":"VE-Z",
         "qs_pg:id":1083881,
         "unlc:id":"VE-Z",
         "wd:id":"Q170453",
         "wk:page":"Amazonas (Venezuelan state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52ef520f8e279d7e91a5079e1ab991fa",
+    "wof:geomhash":"fb7a66d33869f149024a8c87c7f7672e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -436,7 +438,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914962,
+    "wof:lastmodified":1695884968,
     "wof:name":"Amazonas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/17/85680517.geojson
+++ b/data/856/805/17/85680517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":20.401175,
-    "geom:area_square_m":250721183606.604889,
+    "geom:area_square_m":250721184227.422424,
     "geom:bbox":"-67.44,3.608207,-60.279285,8.447935",
     "geom:latitude":6.243336,
     "geom:longitude":-63.528813,
@@ -419,17 +419,19 @@
         "gn:id":3648106,
         "gp:id":2347682,
         "hasc:id":"VE.BO",
+        "iso:code":"VE-F",
         "iso:id":"VE-F",
         "qs_pg:id":895016,
         "unlc:id":"VE-F",
         "wd:id":"Q191164",
         "wk:page":"Bol\u00edvar (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f28bf9edfe8bab40b81b427c79562e72",
+    "wof:geomhash":"d369b758634c5cbaa80739d8856c8562",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -444,7 +446,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914963,
+    "wof:lastmodified":1695884382,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/21/85680521.geojson
+++ b/data/856/805/21/85680521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.838908,
-    "geom:area_square_m":46888626087.832474,
+    "geom:area_square_m":46888627742.74205,
     "geom:bbox":"-65.721854,7.658333,-62.680171,10.314584",
     "geom:latitude":8.943686,
     "geom:longitude":-64.423907,
@@ -388,17 +388,19 @@
         "gn:id":3649198,
         "gp:id":2347678,
         "hasc:id":"VE.AN",
+        "iso:code":"VE-B",
         "iso:id":"VE-B",
         "qs_pg:id":319297,
         "unlc:id":"VE-B",
         "wd:id":"Q190922",
         "wk:page":"Anzo\u00e1tegui"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a55d9b09e17a99d9143df59d5018e582",
+    "wof:geomhash":"bf15064923f02664b85d45df3df8d45e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -413,7 +415,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914964,
+    "wof:lastmodified":1695884383,
     "wof:name":"Anzo\u00e1tegui",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/25/85680525.geojson
+++ b/data/856/805/25/85680525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.595009,
-    "geom:area_square_m":7246074238.708247,
+    "geom:area_square_m":7246074612.546839,
     "geom:bbox":"-67.88,9.255262,-66.548706,10.542889",
     "geom:latitude":9.974855,
     "geom:longitude":-67.133499,
@@ -378,17 +378,19 @@
         "gn:id":3649110,
         "gp:id":2347680,
         "hasc:id":"VE.AR",
+        "iso:code":"VE-D",
         "iso:id":"VE-D",
         "qs_pg:id":1047609,
         "unlc:id":"VE-D",
         "wd:id":"Q190687",
         "wk:page":"Aragua"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f473f7c836166f12e09ac44eeb5a5df4",
+    "wof:geomhash":"2176c9cb1510bbd3a2d74483801256da",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -403,7 +405,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914968,
+    "wof:lastmodified":1695884968,
     "wof:name":"Aragua",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/33/85680533.geojson
+++ b/data/856/805/33/85680533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098704,
-    "geom:area_square_m":1199870532.381392,
+    "geom:area_square_m":1199870532.381433,
     "geom:bbox":"-67.408429,10.401632,-66.309735,10.63625",
     "geom:latitude":10.547981,
     "geom:longitude":-66.897414,
@@ -360,12 +360,14 @@
         "gn:id":3830309,
         "gp:id":20069993,
         "hasc:id":"VE.VA",
+        "iso:code":"VE-X",
         "iso:id":"VE-X",
         "qs_pg:id":1118081,
         "unlc:id":"VE-X",
         "wd:id":"Q205843",
         "wk:page":"Vargas (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421169209
     ],
@@ -373,7 +375,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9740c9daaa9e5e8dc4302a3862fa04e2",
+    "wof:geomhash":"c34805ce1c8bf7992a0e309dd5870391",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -388,7 +390,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914962,
+    "wof:lastmodified":1695884968,
     "wof:name":"Vargas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/35/85680535.geojson
+++ b/data/856/805/35/85680535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030955,
-    "geom:area_square_m":376389816.46714,
+    "geom:area_square_m":376390155.616149,
     "geom:bbox":"-67.161482,10.386801,-66.860738,10.567283",
     "geom:latitude":10.472288,
     "geom:longitude":-66.992504,
@@ -342,17 +342,19 @@
         "gn:id":3640847,
         "gp:id":2347686,
         "hasc:id":"VE.DF",
+        "iso:code":"VE-A",
         "iso:id":"VE-A",
         "qs_pg:id":235659,
         "unlc:id":"VE-A",
         "wd:id":"Q492791",
         "wk:page":"Capital District (Venezuela)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97e48f90489cac2564529cd5cf8add07",
+    "wof:geomhash":"ebea0b20b06eeed6fa2b936ef6f8dc63",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -367,7 +369,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914961,
+    "wof:lastmodified":1695884968,
     "wof:name":"Distrito Capital",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/39/85680539.geojson
+++ b/data/856/805/39/85680539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02465,
-    "geom:area_square_m":298835726.065944,
+    "geom:area_square_m":298835726.065915,
     "geom:bbox":"-66.821304,10.883722,-63.102417,11.904583",
     "geom:latitude":11.343544,
     "geom:longitude":-65.338694,
@@ -402,17 +402,19 @@
         "gn:id":3640846,
         "gp:id":2347700,
         "hasc:id":"VE.DP",
+        "iso:code":"VE-W",
         "iso:id":"VE-W",
         "qs_pg:id":219637,
         "unlc:id":"VE-W",
         "wd:id":"Q130343",
         "wk:page":"Federal Dependencies of Venezuela"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5205ad075b98e41884e9dce5ca2cff7",
+    "wof:geomhash":"5e0ddd7ed0d1d31c0d7f5c875248e805",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -427,7 +429,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914967,
+    "wof:lastmodified":1695884968,
     "wof:name":"Dependencias Federales",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/43/85680543.geojson
+++ b/data/856/805/43/85680543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.329326,
-    "geom:area_square_m":65114533700.666504,
+    "geom:area_square_m":65114532629.071983,
     "geom:bbox":"-68.022575,7.627586,-64.773693,10.04175",
     "geom:latitude":8.825903,
     "geom:longitude":-66.5284,
@@ -368,17 +368,19 @@
         "gn:id":3640017,
         "gp:id":2347688,
         "hasc:id":"VE.GU",
+        "iso:code":"VE-J",
         "iso:id":"VE-J",
         "qs_pg:id":222854,
         "unlc:id":"VE-J",
         "wd:id":"Q202075",
         "wk:page":"Gu\u00e1rico"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0d096056a5cdbb28a2721bd3961a0d3",
+    "wof:geomhash":"3434c83f4c1473bbcf0612430a56ace5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -393,7 +395,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914965,
+    "wof:lastmodified":1695884383,
     "wof:name":"Gu\u00e1rico",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/47/85680547.geojson
+++ b/data/856/805/47/85680547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.296442,
-    "geom:area_square_m":28012670536.252975,
+    "geom:area_square_m":28012670700.865196,
     "geom:bbox":"-64.059948,8.389829,-61.996954,10.320608",
     "geom:latitude":9.413662,
     "geom:longitude":-63.02274,
@@ -346,17 +346,19 @@
         "gn:id":3632100,
         "gp:id":2347692,
         "hasc:id":"VE.MO",
+        "iso:code":"VE-N",
         "iso:id":"VE-N",
         "qs_pg:id":235660,
         "unlc:id":"VE-N",
         "wd:id":"Q205776",
         "wk:page":"Monagas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae75842b3ea11a965f0fa11f1bef6c00",
+    "wof:geomhash":"bda5ef3ccfa70fd09c27256cb77c601b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -371,7 +373,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914968,
+    "wof:lastmodified":1695884968,
     "wof:name":"Monagas",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/53/85680553.geojson
+++ b/data/856/805/53/85680553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.730074,
-    "geom:area_square_m":8883660592.738249,
+    "geom:area_square_m":8883659961.082762,
     "geom:bbox":"-67.22,9.939981,-65.431009,10.654583",
     "geom:latitude":10.24054,
     "geom:longitude":-66.380737,
@@ -401,17 +401,19 @@
         "gn:id":3632191,
         "gp:id":2347691,
         "hasc:id":"VE.MI",
+        "iso:code":"VE-M",
         "iso:id":"VE-M",
         "qs_pg:id":219633,
         "unlc:id":"VE-M",
         "wd:id":"Q191174",
         "wk:page":"Miranda (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f72cd8b42347a42afd158dc2304c551",
+    "wof:geomhash":"eeca0bdceedfde9f6ae96b4e492b19c1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -426,7 +428,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914967,
+    "wof:lastmodified":1695884969,
     "wof:name":"Miranda",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/57/85680557.geojson
+++ b/data/856/805/57/85680557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087376,
-    "geom:area_square_m":1060619724.806058,
+    "geom:area_square_m":1060619860.487411,
     "geom:bbox":"-64.409615,10.732056,-63.77589,11.18425",
     "geom:latitude":10.986207,
     "geom:longitude":-64.049064,
@@ -370,17 +370,19 @@
         "gn:id":3631462,
         "gp:id":2347693,
         "hasc:id":"VE.NE",
+        "iso:code":"VE-O",
         "iso:id":"VE-O",
         "qs_pg:id":1047656,
         "unlc:id":"VE-O",
         "wd:id":"Q204876",
         "wk:page":"Nueva Esparta"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3db9882e58a22b97a08d4b4d55f0862e",
+    "wof:geomhash":"0abeb37129d1087414f36c781428e0be",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -395,7 +397,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914960,
+    "wof:lastmodified":1695884967,
     "wof:name":"Nueva Esparta",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/61/85680561.geojson
+++ b/data/856/805/61/85680561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.908772,
-    "geom:area_square_m":11051992530.424547,
+    "geom:area_square_m":11051991019.994688,
     "geom:bbox":"-64.518238,10.037587,-61.851196,10.76625",
     "geom:latitude":10.41398,
     "geom:longitude":-63.355145,
@@ -355,17 +355,19 @@
         "gn:id":3626655,
         "gp:id":2347695,
         "hasc:id":"VE.SU",
+        "iso:code":"VE-R",
         "iso:id":"VE-R",
         "qs_pg:id":1047658,
         "unlc:id":"VE-R",
         "wd:id":"Q205824",
         "wk:page":"Sucre (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e7b7bba1fd8f5d081cc4ec2b5eee357a",
+    "wof:geomhash":"78cdbe2af56a6bf4bde9c6284ea3765b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -380,7 +382,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914960,
+    "wof:lastmodified":1695884968,
     "wof:name":"Sucre",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/856/805/65/85680565.geojson
+++ b/data/856/805/65/85680565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.12316,
-    "geom:area_square_m":38164077726.405273,
+    "geom:area_square_m":38164079056.584587,
     "geom:bbox":"-62.606779,7.758151,-59.805666,10.057889",
     "geom:latitude":8.780515,
     "geom:longitude":-61.322458,
@@ -375,17 +375,19 @@
         "gn:id":3644541,
         "gp:id":2347685,
         "hasc:id":"VE.DA",
+        "iso:code":"VE-Y",
         "iso:id":"VE-Y",
         "qs_pg:id":1285591,
         "unlc:id":"VE-Y",
         "wd:id":"Q201137",
         "wk:page":"Delta Amacuro"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"VE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b431c93197cd35b4721ccb814bfb8f17",
+    "wof:geomhash":"cc1c589d239ca53c23cff323b1fca9a2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -400,7 +402,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690914966,
+    "wof:lastmodified":1695884383,
     "wof:name":"Delta Amacuro",
     "wof:parent_id":85632317,
     "wof:placetype":"region",

--- a/data/890/417/393/890417393.geojson
+++ b/data/890/417/393/890417393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068989,
-    "geom:area_square_m":838113946.627176,
+    "geom:area_square_m":838113754.868544,
     "geom:bbox":"-68.621517,10.5775,-68.224202,10.879827",
     "geom:latitude":10.740826,
     "geom:longitude":-68.419216,
@@ -713,12 +713,13 @@
         "wd:id":"Q6327150",
         "wk:page":"Silva"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469051199,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab881f2bf6ceeae2af7d18c8efd69b79",
+    "wof:geomhash":"7fa6ddd6c64d1522e8d000498da7b9ae",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -728,7 +729,7 @@
         }
     ],
     "wof:id":890417393,
-    "wof:lastmodified":1690915132,
+    "wof:lastmodified":1695886201,
     "wof:name":"Silva",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/890/420/047/890420047.geojson
+++ b/data/890/420/047/890420047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.747727,
-    "geom:area_square_m":46279145160.846527,
+    "geom:area_square_m":46279145185.902763,
     "geom:bbox":"-66.069286,1.480971,-63.363197,4.172697",
     "geom:latitude":2.901765,
     "geom:longitude":-64.906095,
@@ -166,12 +166,13 @@
         "wd:id":"Q443529",
         "wk:page":"Alto Orinoco Municipality"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469051314,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8d1b91ce99700131a08de8e0932b3cb",
+    "wof:geomhash":"54cc7fcf6e0c50f7abf20b9c5d60fd27",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":890420047,
-    "wof:lastmodified":1690915135,
+    "wof:lastmodified":1695886201,
     "wof:name":"Alto Orinoco",
     "wof:parent_id":85680511,
     "wof:placetype":"county",

--- a/data/890/429/493/890429493.geojson
+++ b/data/890/429/493/890429493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28382,
-    "geom:area_square_m":3472773148.391246,
+    "geom:area_square_m":3472773081.106566,
     "geom:bbox":"-70.491981,7.940026,-69.45,8.741667",
     "geom:latitude":8.292059,
     "geom:longitude":-70.029651,
@@ -120,12 +120,13 @@
         "wd:id":"Q2884525",
         "wk:page":"Barinas Municipality"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469051816,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f445e2930ae82c65cacbd89b829bedcf",
+    "wof:geomhash":"88481800cb41a9c08d35b5b3d239d1e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890429493,
-    "wof:lastmodified":1690915134,
+    "wof:lastmodified":1695886197,
     "wof:name":"Barinas",
     "wof:parent_id":85680469,
     "wof:placetype":"county",

--- a/data/890/439/859/890439859.geojson
+++ b/data/890/439/859/890439859.geojson
@@ -66,6 +66,7 @@
         "hasc:id":"VE.TR.TR",
         "qs_pg:id":757580
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052252,
     "wof:geom_alt":[
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":890439859,
-    "wof:lastmodified":1694492874,
+    "wof:lastmodified":1695886373,
     "wof:name":"Pampanito",
     "wof:parent_id":85680483,
     "wof:placetype":"county",

--- a/data/890/440/759/890440759.geojson
+++ b/data/890/440/759/890440759.geojson
@@ -72,6 +72,7 @@
         "hasc:id":"VE.DP.DP",
         "qs_pg:id":1263797
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052296,
     "wof:geom_alt":[
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":890440759,
-    "wof:lastmodified":1694492874,
+    "wof:lastmodified":1695886375,
     "wof:name":"Peninsula De Macanao",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/890/441/467/890441467.geojson
+++ b/data/890/441/467/890441467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015812,
-    "geom:area_square_m":191978864.904719,
+    "geom:area_square_m":191978327.21275,
     "geom:bbox":"-64.229584,10.795417,-63.990417,11.00951",
     "geom:latitude":10.923571,
     "geom:longitude":-64.088716,
@@ -143,12 +143,13 @@
         "wd:id":"Q2102962",
         "wk:page":"Tubores Municipality"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052324,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a875f6d8a2387fe1250b0d68b17c5b7d",
+    "wof:geomhash":"32d5eb94221c83025b77945f3c6ace5b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":890441467,
-    "wof:lastmodified":1690915129,
+    "wof:lastmodified":1695886201,
     "wof:name":"Tubores",
     "wof:parent_id":85680557,
     "wof:placetype":"county",

--- a/data/890/442/023/890442023.geojson
+++ b/data/890/442/023/890442023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020373,
-    "geom:area_square_m":246565623.582261,
+    "geom:area_square_m":246565700.143801,
     "geom:bbox":"-70.298752,11.723323,-70.118192,11.951871",
     "geom:latitude":11.830732,
     "geom:longitude":-70.207826,
@@ -83,12 +83,13 @@
         "hasc:id":"VE.FA.LT",
         "qs_pg:id":1314598
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052347,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7418f64ffd2d5a6ba55e007150194369",
+    "wof:geomhash":"0c4b895557e03bda5d5892d0b0becba5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":890442023,
-    "wof:lastmodified":1627522971,
+    "wof:lastmodified":1695886181,
     "wof:name":"Los Taques",
     "wof:parent_id":85680461,
     "wof:placetype":"county",

--- a/data/890/450/029/890450029.geojson
+++ b/data/890/450/029/890450029.geojson
@@ -113,7 +113,7 @@
         }
     ],
     "wof:id":890450029,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886201,
     "wof:name":"Carvajal",
     "wof:parent_id":85680521,
     "wof:placetype":"county",

--- a/data/890/450/031/890450031.geojson
+++ b/data/890/450/031/890450031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006933,
-    "geom:area_square_m":84348505.284429,
+    "geom:area_square_m":84348548.88902,
     "geom:bbox":"-68.79786,10.218171,-68.671652,10.409831",
     "geom:latitude":10.304166,
     "geom:longitude":-68.726502,
@@ -124,12 +124,13 @@
         "wd:id":"Q607774",
         "wk:page":"Independencia, Venezuela"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052721,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd2f54907af185eca8a3138a0a531232",
+    "wof:geomhash":"0a6b532b388fe23bd0a62b880029c950",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":890450031,
-    "wof:lastmodified":1690915142,
+    "wof:lastmodified":1695886198,
     "wof:name":"Independencia",
     "wof:parent_id":85680507,
     "wof:placetype":"county",

--- a/data/890/451/975/890451975.geojson
+++ b/data/890/451/975/890451975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055559,
-    "geom:area_square_m":672677760.451482,
+    "geom:area_square_m":672677915.122492,
     "geom:bbox":"-70.235474,11.607056,-69.808226,11.850687",
     "geom:latitude":11.718337,
     "geom:longitude":-70.016184,
@@ -120,12 +120,13 @@
         "qs_pg:id":219079,
         "wd:id":"Q262132"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"VE",
     "wof:created":1469052800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8f2e99034ed85a337fac447a9a992d66",
+    "wof:geomhash":"7a0f59b6f6f81a419677490f677e6f57",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":890451975,
-    "wof:lastmodified":1690915140,
+    "wof:lastmodified":1695886201,
     "wof:name":"Carirubana",
     "wof:parent_id":85680461,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.